### PR TITLE
Split name and namespace

### DIFF
--- a/examples/resources/namespace/namespace.tf
+++ b/examples/resources/namespace/namespace.tf
@@ -3,8 +3,8 @@ provider "temporalcloud" {
 }
 
 resource "temporalcloud_namespace" "swgillespie-dev" {
-  name               = "swgillespie"
+  name               = "swgillespie-terraform"
   region             = "us-east-1"
   accepted_client_ca = base64encode(file("${path.module}/ca.pem"))
-  retention_days     = 30
+  retention_days     = 45
 }

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -41,11 +41,15 @@ import (
 
 // Client is a client for the Temporal Cloud API.
 type Client struct {
-	conn *grpc.ClientConn
+	conn      *grpc.ClientConn
+	accountID string
 }
 
 // NewClient creates a new client for the Temporal Cloud API using the given API key.
-func NewClient(apiKey string) (*Client, error) {
+//
+// The account ID parameter should be temporary until there is a way for this provider to discover the Account ID
+// via API.
+func NewClient(apiKey string, accountID string) (*Client, error) {
 	apiKeyCreds, err := apikey.NewCredential(apiKey)
 	if err != nil {
 		return nil, err
@@ -61,7 +65,11 @@ func NewClient(apiKey string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{conn: conn}, nil
+	return &Client{conn: conn, accountID: accountID}, nil
+}
+
+func (c *Client) GetAccountID() string {
+	return c.accountID
 }
 
 func (c *Client) NamespaceService() namespaceservice.NamespaceServiceClient {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,7 +25,8 @@ type TerraformCloudProvider struct {
 
 // TerraformCloudProvider describes the provider data model.
 type TerraformCloudProviderModel struct {
-	APIKey types.String `tfsdk:"api_key"`
+	APIKey    types.String `tfsdk:"api_key"`
+	AccountID types.String `tfsdk:"account_id"`
 }
 
 func (p *TerraformCloudProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -37,6 +38,10 @@ func (p *TerraformCloudProvider) Schema(ctx context.Context, req provider.Schema
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"api_key": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+			},
+			"account_id": schema.StringAttribute{
 				Optional:  true,
 				Sensitive: true,
 			},
@@ -60,12 +65,30 @@ func (p *TerraformCloudProvider) Configure(ctx context.Context, req provider.Con
 		return
 	}
 
+	if data.AccountID.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("account_id"),
+			"Unknown Terraform Cloud Account ID",
+			"The provider cannot create a Terraform Cloud API client as there is an unknown configuration value for the Temporal Cloud Account ID."+
+				" Either apply the source of the value first, or statically set the Account ID via environment variable or in configuration.")
+		return
+	}
+
 	apiKey := os.Getenv("TEMPORAL_CLOUD_API_KEY")
+	accountID := os.Getenv("TEMPORAL_CLOUD_ACCOUNT_ID")
 	if !data.APIKey.IsNull() {
 		apiKey = data.APIKey.ValueString()
 	}
+	if !data.AccountID.IsNull() {
+		accountID = data.AccountID.ValueString()
+	}
 
-	client, err := NewClient(apiKey)
+	if accountID == "" {
+		resp.Diagnostics.AddError("Failed to connect to Temporal Cloud API", "An Account ID is required")
+		return
+	}
+
+	client, err := NewClient(apiKey, accountID)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to connect to Temporal Cloud API", err.Error())
 		return


### PR DESCRIPTION
Name is now the user-provided name of the namespace; Namespace is the Temporal Cloud generated name of the namespace (concatenated with the account ID). This commit also makes account ID a property of the provider, so that the provider can infer what the Temporal Cloud generated name of a namespace is going to be post-creation.
