### PR TITLE
Use RequestID in RequestStatus to infer namespace name

### DIFF
--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -41,15 +41,14 @@ import (
 
 // Client is a client for the Temporal Cloud API.
 type Client struct {
-	conn      *grpc.ClientConn
-	accountID string
+	conn *grpc.ClientConn
 }
 
 // NewClient creates a new client for the Temporal Cloud API using the given API key.
 //
 // The account ID parameter should be temporary until there is a way for this provider to discover the Account ID
 // via API.
-func NewClient(apiKey string, accountID string) (*Client, error) {
+func NewClient(apiKey string) (*Client, error) {
 	apiKeyCreds, err := apikey.NewCredential(apiKey)
 	if err != nil {
 		return nil, err
@@ -65,11 +64,7 @@ func NewClient(apiKey string, accountID string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{conn: conn, accountID: accountID}, nil
-}
-
-func (c *Client) GetAccountID() string {
-	return c.accountID
+	return &Client{conn: conn}, nil
 }
 
 func (c *Client) NamespaceService() namespaceservice.NamespaceServiceClient {

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -162,9 +162,7 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	// This is a kludge, but there doesn't appear to be a way to link the requested namespace name with the one that
-	// is actually provided without manually appending the account ID to the namespace name.
-	nsName := fmt.Sprintf("%s.%s", plan.Name.ValueString(), r.client.GetAccountID())
+	nsName := svcResp.RequestStatus.ResourceId
 	tflog.Debug(ctx, "querying namespace for existence", map[string]any{
 		"name": nsName,
 	})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,8 +25,7 @@ type TerraformCloudProvider struct {
 
 // TerraformCloudProvider describes the provider data model.
 type TerraformCloudProviderModel struct {
-	APIKey    types.String `tfsdk:"api_key"`
-	AccountID types.String `tfsdk:"account_id"`
+	APIKey types.String `tfsdk:"api_key"`
 }
 
 func (p *TerraformCloudProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -38,10 +37,6 @@ func (p *TerraformCloudProvider) Schema(ctx context.Context, req provider.Schema
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"api_key": schema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
-			},
-			"account_id": schema.StringAttribute{
 				Optional:  true,
 				Sensitive: true,
 			},
@@ -65,30 +60,12 @@ func (p *TerraformCloudProvider) Configure(ctx context.Context, req provider.Con
 		return
 	}
 
-	if data.AccountID.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("account_id"),
-			"Unknown Terraform Cloud Account ID",
-			"The provider cannot create a Terraform Cloud API client as there is an unknown configuration value for the Temporal Cloud Account ID."+
-				" Either apply the source of the value first, or statically set the Account ID via environment variable or in configuration.")
-		return
-	}
-
 	apiKey := os.Getenv("TEMPORAL_CLOUD_API_KEY")
-	accountID := os.Getenv("TEMPORAL_CLOUD_ACCOUNT_ID")
 	if !data.APIKey.IsNull() {
 		apiKey = data.APIKey.ValueString()
 	}
-	if !data.AccountID.IsNull() {
-		accountID = data.AccountID.ValueString()
-	}
 
-	if accountID == "" {
-		resp.Diagnostics.AddError("Failed to connect to Temporal Cloud API", "An Account ID is required")
-		return
-	}
-
-	client, err := NewClient(apiKey, accountID)
+	client, err := NewClient(apiKey)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to connect to Temporal Cloud API", err.Error())
 		return


### PR DESCRIPTION
This avoids having to pass in the account ID as configuration to the provider.
