### PR TITLE
map empty certificate filter lists to null lists

### DIFF
--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -8,13 +8,42 @@ import (
 )
 
 func TestAccBasicNamespace(t *testing.T) {
+	config := func(name string, retention int) string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_namespace" "terraform" {
+  name               = "%s"
+  regions            = ["aws-us-east-1"]
+  accepted_client_ca = base64encode(<<PEM
+-----BEGIN CERTIFICATE-----
+MIIByTCCAVCgAwIBAgIRAWHkC+6JUf3s9Tq43mdp2zgwCgYIKoZIzj0EAwMwEzER
+MA8GA1UEChMIdGVtcG9yYWwwHhcNMjMwODEwMDAwOTQ1WhcNMjQwODA5MDAxMDQ1
+WjATMREwDwYDVQQKEwh0ZW1wb3JhbDB2MBAGByqGSM49AgEGBSuBBAAiA2IABCzQ
+7DwwGSQKM6Zrx3Qtw7IubfxiJ3RSXCqmcGhEbFVeocwAdEgMYlwSlUiWtDZVR2dM
+XM9UZLWK4aGGnDNS5Mhcz6ibSBS7Owf4tRZZA9SpFCjNw2HraaiUVV+EUgxoe6No
+MGYwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFG4N
+8lIXqQKxwVs/ixVzdF6XGZm+MCQGA1UdEQQdMBuCGWNsaWVudC5yb290LnRlbXBv
+cmFsLlB1VHMwCgYIKoZIzj0EAwMDZwAwZAIwRLfm9S7rKGd30KdQvUMcOcDJlmDw
+6/oM6UOJFxLeGcpYbgxQ/bFize+Yx9Q9kNeMAjA7GiFsaipaKtWHy5MCOCas3ZP6
++ttLaXNXss3Z5Wk5vhDQnyE8JR3rPeQ2cHXLiA0=
+-----END CERTIFICATE-----
+PEM
+)
+
+  retention_days     = %d
+}`, name, retention)
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				// New namespace with retention of 7
-				Config: testAccBasicNamespaceConfig("terraform-test", 7),
+				Config: config("tf-basic-namespace", 7),
 			},
 			/* Does not work yet: CLD-1971
 			{
@@ -25,10 +54,12 @@ func TestAccBasicNamespace(t *testing.T) {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+
 }
 
-func testAccBasicNamespaceConfig(name string, retention int) string {
-	return fmt.Sprintf(`
+func TestAccBasicNamespaceWithCertFilters(t *testing.T) {
+	config := func(name string, retention int) string {
+		return fmt.Sprintf(`
 provider "temporalcloud" {
 
 }
@@ -61,4 +92,24 @@ PEM
 
 }
 	`, name, retention)
+
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// New namespace with retention of 7
+				Config: config("terraform-test", 7),
+			},
+			/* Does not work yet: CLD-1971
+			{
+				// Update retention to 14
+				Config: testAccBasicNamespaceConfig("terraform-test", 14),
+			},
+			*/
+			// Delete testing automatically occurs in TestCase
+		},
+	})
 }


### PR DESCRIPTION
Terraform considers the null list and the empty list to be two separate values, in the same way that Go does. To ensure consistency, this commit explicitly transforms missing certificate filter lists into null lists in both directions (TF -> API and API -> TF).

Fixes this issue:

```
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to temporalcloud_namespace.terraform, provider "provider[\"registry.terraform.io/hashicorp/temporalcloud\"]"
│ produced an unexpected new value: .certificate_filters: was null, but now
│ cty.ListValEmpty(cty.Object(map[string]cty.Type{"common_name":cty.String, "organization":cty.String,
│ "organizational_unit":cty.String, "subject_alternative_name":cty.String})).
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
