### PR TITLE
Force replacement of namespace if its name or region changes

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -32,11 +32,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-<<<<<<< HEAD
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-=======
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
->>>>>>> main
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -124,14 +124,6 @@ PEM
 	})
 }
 
-<<<<<<< HEAD
-func TestAccNamespaceRenameForcesReplacement(t *testing.T) {
-	t.Parallel()
-	oldName := fmt.Sprintf("%s-%s", "tf-rename-replace", randomString(10))
-	newName := fmt.Sprintf("%s-%s", "tf-rename-replace-new", randomString(10))
-	config := func(name string) string {
-		return fmt.Sprintf(`
-=======
 func TestAccNamespaceWithCodecServer(t *testing.T) {
 	type (
 		codecServer struct {
@@ -150,17 +142,12 @@ func TestAccNamespaceWithCodecServer(t *testing.T) {
 	t.Parallel()
 	name := fmt.Sprintf("%s-%s", "tf-codec-server", randomString(10))
 	tmpl := template.Must(template.New("config").Parse(`
->>>>>>> main
 provider "temporalcloud" {
 
 }
 
 resource "temporalcloud_namespace" "test" {
-<<<<<<< HEAD
-  name               = "%s"
-=======
   name               = "{{ .Name }}"
->>>>>>> main
   regions            = ["aws-us-east-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
@@ -177,11 +164,6 @@ cmFsLlB1VHMwCgYIKoZIzj0EAwMDZwAwZAIwRLfm9S7rKGd30KdQvUMcOcDJlmDw
 -----END CERTIFICATE-----
 PEM
 )
-<<<<<<< HEAD
-  retention_days     = 7
-}
-`, name)
-=======
 
   retention_days     = {{ .RetentionDays }}
 
@@ -204,7 +186,6 @@ PEM
 
 		writer.Flush()
 		return buf.String()
->>>>>>> main
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -212,15 +193,6 @@ PEM
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-<<<<<<< HEAD
-				Config: config(oldName),
-			},
-			{
-				Config: config(newName),
-			},
-		},
-	})
-=======
 				Config: config(configArgs{
 					Name:          name,
 					RetentionDays: 7,
@@ -284,7 +256,51 @@ PEM
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
 
+func TestAccNamespaceRenameForcesReplacement(t *testing.T) {
+	t.Parallel()
+	oldName := fmt.Sprintf("%s-%s", "tf-rename-replace", randomString(10))
+	newName := fmt.Sprintf("%s-%s", "tf-rename-replace-new", randomString(10))
+	config := func(name string) string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+}
+resource "temporalcloud_namespace" "test" {
+  name               = "%s"
+  regions            = ["aws-us-east-1"]
+  accepted_client_ca = base64encode(<<PEM
+-----BEGIN CERTIFICATE-----
+MIIByTCCAVCgAwIBAgIRAWHkC+6JUf3s9Tq43mdp2zgwCgYIKoZIzj0EAwMwEzER
+MA8GA1UEChMIdGVtcG9yYWwwHhcNMjMwODEwMDAwOTQ1WhcNMjQwODA5MDAxMDQ1
+WjATMREwDwYDVQQKEwh0ZW1wb3JhbDB2MBAGByqGSM49AgEGBSuBBAAiA2IABCzQ
+7DwwGSQKM6Zrx3Qtw7IubfxiJ3RSXCqmcGhEbFVeocwAdEgMYlwSlUiWtDZVR2dM
+XM9UZLWK4aGGnDNS5Mhcz6ibSBS7Owf4tRZZA9SpFCjNw2HraaiUVV+EUgxoe6No
+MGYwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFG4N
+8lIXqQKxwVs/ixVzdF6XGZm+MCQGA1UdEQQdMBuCGWNsaWVudC5yb290LnRlbXBv
+cmFsLlB1VHMwCgYIKoZIzj0EAwMDZwAwZAIwRLfm9S7rKGd30KdQvUMcOcDJlmDw
+6/oM6UOJFxLeGcpYbgxQ/bFize+Yx9Q9kNeMAjA7GiFsaipaKtWHy5MCOCas3ZP6
++ttLaXNXss3Z5Wk5vhDQnyE8JR3rPeQ2cHXLiA0=
+-----END CERTIFICATE-----
+PEM
+)
+  retention_days     = 7
+}
+`, name)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(oldName),
+			},
+			{
+				Config: config(newName),
+			},
+		},
+	})
 }
 
 func newConnection(t *testing.T) cloudservicev1.CloudServiceClient {
@@ -301,7 +317,6 @@ func newConnection(t *testing.T) cloudservicev1.CloudServiceClient {
 	}
 
 	return client
->>>>>>> main
 }
 
 func randomString(length int) string {


### PR DESCRIPTION
This commit adds plan modifiers to `name` and `regions` such that changes to either will force a replacement of the whole namespace.
