### PR TITLE
Run unit tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
           cache: true
       - run: go mod download
       - run: go build -v .
+      - run: go test -cover ./...
       - name: Run linters
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         with:


### PR DESCRIPTION
#56 broke unit tests but we didn't know because we don't try to run tests until after the linter runs, and the linter was having problems.