### PR TITLE
feature: Add import to namespace search attribute

### DIFF
--- a/internal/provider/namespace_search_attribute_resource_test.go
+++ b/internal/provider/namespace_search_attribute_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccNamespaceWithSearchAttributes(t *testing.T) {
@@ -67,5 +68,61 @@ resource "temporalcloud_namespace_search_attribute" "custom_search_attribute3" {
 			},
 		},
 	})
+}
 
+func TestAccNamespaceImportSearchAttribute(t *testing.T) {
+	name := fmt.Sprintf("%s-%s", "tf-search-attribute-import", randomString())
+	config := func(name string, saName string) string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_namespace" "terraform" {
+  name               = "%s"
+  regions            = ["aws-us-east-1"]
+  retention_days     = 7
+  accepted_client_ca = base64encode(<<PEM
+-----BEGIN CERTIFICATE-----
+MIIByTCCAVCgAwIBAgIRAWHkC+6JUf3s9Tq43mdp2zgwCgYIKoZIzj0EAwMwEzER
+MA8GA1UEChMIdGVtcG9yYWwwHhcNMjMwODEwMDAwOTQ1WhcNMjQwODA5MDAxMDQ1
+WjATMREwDwYDVQQKEwh0ZW1wb3JhbDB2MBAGByqGSM49AgEGBSuBBAAiA2IABCzQ
+7DwwGSQKM6Zrx3Qtw7IubfxiJ3RSXCqmcGhEbFVeocwAdEgMYlwSlUiWtDZVR2dM
+XM9UZLWK4aGGnDNS5Mhcz6ibSBS7Owf4tRZZA9SpFCjNw2HraaiUVV+EUgxoe6No
+MGYwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFG4N
+8lIXqQKxwVs/ixVzdF6XGZm+MCQGA1UdEQQdMBuCGWNsaWVudC5yb290LnRlbXBv
+cmFsLlB1VHMwCgYIKoZIzj0EAwMDZwAwZAIwRLfm9S7rKGd30KdQvUMcOcDJlmDw
+6/oM6UOJFxLeGcpYbgxQ/bFize+Yx9Q9kNeMAjA7GiFsaipaKtWHy5MCOCas3ZP6
++ttLaXNXss3Z5Wk5vhDQnyE8JR3rPeQ2cHXLiA0=
+-----END CERTIFICATE-----
+PEM
+)
+}
+
+resource "temporalcloud_namespace_search_attribute" "custom_search_attribute" {
+  namespace_id = temporalcloud_namespace.terraform.id
+  name         = "%s"
+  type         = "Text"
+}
+`, name, saName)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(name, "CustomSearchAttribute"),
+			},
+			{
+				ResourceName: "temporalcloud_namespace_search_attribute.custom_search_attribute",
+				ImportState:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					ns := s.Modules[0].Resources["temporalcloud_namespace.terraform"]
+					id := ns.Primary.Attributes["id"]
+					return fmt.Sprintf("%s/%s", id, "CustomSearchAttribute"), nil
+				},
+			},
+		},
+	})
 }


### PR DESCRIPTION
Now it is possible to fully adopt all resources into a Terraform program that this provider supports. This commit supports Import by requiring that users specify a qualified ID for a search attribute, of the form `namespace/name`.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
