### PR TITLE
Misc fixes for issues found when running the release provider

### DIFF
--- a/docs/data-sources/regions.md
+++ b/docs/data-sources/regions.md
@@ -13,6 +13,14 @@ description: |-
 ## Example Usage
 
 ```terraform
+terraform {
+  required_providers {
+    temporalcloud = {
+      source = "temporalio/temporalcloud"
+    }
+  }
+}
+
 provider "temporalcloud" {
 
 }
@@ -37,7 +45,7 @@ output "regions" {
 
 Read-Only:
 
-- `cloud_provider` (String)
-- `cloud_provider_region` (String)
-- `id` (String)
-- `location` (String)
+- `cloud_provider` (String) The name of the Cloud provider for this region, e.g. `aws`.
+- `cloud_provider_region` (String) The name of the region within the Cloud provider, e.g. `us-east-1`.
+- `id` (String) The unique identifier for the region, e.g. `aws-us-east-1`.
+- `location` (String) The physical location of the region, e.g. "US East (N. Virginia)".

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ in version control. We recommend passing credentials to this provider via enviro
 terraform {
   required_providers {
     temporalcloud = {
-      source = "hashicorp/temporalcloud"
+      source = "temporalio/temporalcloud"
     }
   }
 }

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -13,6 +13,14 @@ Provisions a Temporal Cloud namespace.
 ## Example Usage
 
 ```terraform
+terraform {
+  required_providers {
+    temporalcloud = {
+      source = "temporalio/temporalcloud"
+    }
+  }
+}
+
 provider "temporalcloud" {
 
 }
@@ -66,7 +74,7 @@ Required:
 Optional:
 
 - `include_cross_origin_credentials` (Boolean) If true, Temporal Cloud will include cross-origin credentials in requests to the codec server.
-- `pass_access_token` (Boolean) If true, Tempora Cloud will pass the access token to the codec server upon each request.
+- `pass_access_token` (Boolean) If true, Temporal Cloud will pass the access token to the codec server upon each request.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/namespace_search_attribute.md
+++ b/docs/resources/namespace_search_attribute.md
@@ -13,6 +13,14 @@ A search attribute for visibility of Temporal Cloud namespaces. See [this docume
 ## Example Usage
 
 ```terraform
+terraform {
+  required_providers {
+    temporalcloud = {
+      source = "temporalio/temporalcloud"
+    }
+  }
+}
+
 provider "temporalcloud" {
 
 }

--- a/examples/data-sources/temporalcloud_regions/data-source.tf
+++ b/examples/data-sources/temporalcloud_regions/data-source.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    temporalcloud = {
+      source = "temporalio/temporalcloud"
+    }
+  }
+}
+
 provider "temporalcloud" {
 
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     temporalcloud = {
-      source = "hashicorp/temporalcloud"
+      source = "temporalio/temporalcloud"
     }
   }
 }

--- a/examples/resources/temporalcloud_namespace/resource.tf
+++ b/examples/resources/temporalcloud_namespace/resource.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    temporalcloud = {
+      source = "temporalio/temporalcloud"
+    }
+  }
+}
+
 provider "temporalcloud" {
 
 }

--- a/examples/resources/temporalcloud_namespace_search_attribute/resource.tf
+++ b/examples/resources/temporalcloud_namespace_search_attribute/resource.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    temporalcloud = {
+      source = "temporalio/temporalcloud"
+    }
+  }
+}
+
 provider "temporalcloud" {
 
 }

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -193,7 +193,7 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 						Required:    true,
 					},
 					"pass_access_token": schema.BoolAttribute{
-						Description: "If true, Tempora Cloud will pass the access token to the codec server upon each request.",
+						Description: "If true, Temporal Cloud will pass the access token to the codec server upon each request.",
 						Computed:    true,
 						Default:     booldefault.StaticBool(false),
 						Optional:    true,

--- a/internal/provider/regions_datasource.go
+++ b/internal/provider/regions_datasource.go
@@ -75,16 +75,20 @@ func (d *regionsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier for the region, e.g. `aws-us-east-1`.",
+							Computed:    true,
 						},
 						"cloud_provider": schema.StringAttribute{
-							Computed: true,
+							Description: "The name of the Cloud provider for this region, e.g. `aws`.",
+							Computed:    true,
 						},
 						"cloud_provider_region": schema.StringAttribute{
-							Computed: true,
+							Description: "The name of the region within the Cloud provider, e.g. `us-east-1`.",
+							Computed:    true,
 						},
 						"location": schema.StringAttribute{
-							Computed: true,
+							Description: "The physical location of the region, e.g. \"US East (N. Virginia)\".",
+							Computed:    true,
 						},
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/hashicorp/temporalcloud",
+		Address: "registry.terraform.io/temporalio/temporalcloud",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
1. Some documentation fixups. Some fields (like on `temporalcloud_region`) were lacking documentation, others had some typos.
2. The released provider is in `temporalio/temporalcloud`, not `hashicorp/temporalcloud`. I added `required_provider` stanzas to each example and changed the reported name of the provider to match the organization that we're actually publishing the provider from.