### PR TITLE
bug(#75) - Reload entire namespace spec on update

### DIFF
--- a/internal/provider/namespace_search_attribute_resource_test.go
+++ b/internal/provider/namespace_search_attribute_resource_test.go
@@ -126,3 +126,54 @@ resource "temporalcloud_namespace_search_attribute" "custom_search_attribute" {
 		},
 	})
 }
+
+func TestAccNamespaceWithSearchAttributesUpdate(t *testing.T) {
+	name := fmt.Sprintf("%s-%s", "tf-search-attributes", randomString())
+	config := func(name string, retentionDays int) string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_namespace" "terraform" {
+  name               = "%s"
+  regions            = ["aws-us-east-1"]
+  retention_days     = %d
+  accepted_client_ca = base64encode(<<PEM
+-----BEGIN CERTIFICATE-----
+MIIByTCCAVCgAwIBAgIRAWHkC+6JUf3s9Tq43mdp2zgwCgYIKoZIzj0EAwMwEzER
+MA8GA1UEChMIdGVtcG9yYWwwHhcNMjMwODEwMDAwOTQ1WhcNMjQwODA5MDAxMDQ1
+WjATMREwDwYDVQQKEwh0ZW1wb3JhbDB2MBAGByqGSM49AgEGBSuBBAAiA2IABCzQ
+7DwwGSQKM6Zrx3Qtw7IubfxiJ3RSXCqmcGhEbFVeocwAdEgMYlwSlUiWtDZVR2dM
+XM9UZLWK4aGGnDNS5Mhcz6ibSBS7Owf4tRZZA9SpFCjNw2HraaiUVV+EUgxoe6No
+MGYwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFG4N
+8lIXqQKxwVs/ixVzdF6XGZm+MCQGA1UdEQQdMBuCGWNsaWVudC5yb290LnRlbXBv
+cmFsLlB1VHMwCgYIKoZIzj0EAwMDZwAwZAIwRLfm9S7rKGd30KdQvUMcOcDJlmDw
+6/oM6UOJFxLeGcpYbgxQ/bFize+Yx9Q9kNeMAjA7GiFsaipaKtWHy5MCOCas3ZP6
++ttLaXNXss3Z5Wk5vhDQnyE8JR3rPeQ2cHXLiA0=
+-----END CERTIFICATE-----
+PEM
+)
+}
+
+resource "temporalcloud_namespace_search_attribute" "custom_search_attribute" {
+  namespace_id = temporalcloud_namespace.terraform.id
+  name         = "CustomSearchAttribute"
+  type         = "Text"
+}
+`, name, retentionDays)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(name, 14),
+			},
+			{
+				Config: config(name, 15),
+			},
+		},
+	})
+}


### PR DESCRIPTION
The namespace spec retrieved from the API contains both search attributes and all other resources managed by the `namespace` resource. Since search attributes are managed by a different resource, we have to be sure to load them all here, otherwise we'll send an update request to the server that doesn't contain any search attributes.