### PR TITLE
Make account roles and namespace permissions case insensitive

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -107,6 +107,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"account_access": schema.StringAttribute{
+				CustomType:  internaltypes.CaseInsensitiveStringType{},
 				Description: "The role on the account. Must be one of [admin, developer, read] (case-insensitive)",
 				Required:    true,
 				Validators: []validator.String{
@@ -123,6 +124,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 							Required:    true,
 						},
 						"permission": schema.StringAttribute{
+							CustomType:  internaltypes.CaseInsensitiveStringType{},
 							Description: "The permission to assign. Must be one of [admin, write, read] (case-insensitive)",
 							Required:    true,
 							Validators: []validator.String{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -167,7 +168,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 			Email: plan.Email.ValueString(),
 			Access: &identityv1.Access{
 				AccountAccess: &identityv1.AccountAccess{
-					Role: plan.AccountAccess.ValueString(),
+					Role: strings.ToLower(plan.AccountAccess.ValueString()),
 				},
 				NamespaceAccesses: namespaceAccesses,
 			},
@@ -240,7 +241,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			Email: plan.Email.ValueString(),
 			Access: &identityv1.Access{
 				AccountAccess: &identityv1.AccountAccess{
-					Role: plan.AccountAccess.ValueString(),
+					Role: strings.ToLower(plan.AccountAccess.ValueString()),
 				},
 				NamespaceAccesses: namespaceAccesses,
 			},
@@ -330,7 +331,7 @@ func getNamespaceAccessesFromModel(ctx context.Context, diags diag.Diagnostics, 
 			return nil
 		}
 		namespaceAccesses[model.NamespaceID.ValueString()] = &identityv1.NamespaceAccess{
-			Permission: model.Permission.ValueString(),
+			Permission: strings.ToLower(model.Permission.ValueString()),
 		}
 	}
 
@@ -341,7 +342,7 @@ func updateUserModelFromSpec(ctx context.Context, diags diag.Diagnostics, state 
 	state.ID = types.StringValue(user.GetId())
 	state.State = types.StringValue(user.GetState())
 	state.Email = types.StringValue(user.GetSpec().GetEmail())
-	state.AccountAccess = types.StringValue(user.GetSpec().GetAccess().GetAccountAccess().GetRole())
+	state.AccountAccess = types.StringValue(strings.ToLower(user.GetSpec().GetAccess().GetAccountAccess().GetRole()))
 
 	namespaceAccesses := types.ListNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs})
 	if len(user.GetSpec().GetAccess().GetNamespaceAccesses()) > 0 {
@@ -349,7 +350,7 @@ func updateUserModelFromSpec(ctx context.Context, diags diag.Diagnostics, state 
 		for ns, namespaceAccess := range user.GetSpec().GetAccess().GetNamespaceAccesses() {
 			model := userNamespaceAccessModel{
 				NamespaceID: types.StringValue(ns),
-				Permission:  types.StringValue(namespaceAccess.GetPermission()),
+				Permission:  types.StringValue(strings.ToLower(namespaceAccess.GetPermission())),
 			}
 			obj, d := types.ObjectValueFrom(ctx, userNamespaceAccessAttrs, model)
 			diags.Append(d...)

--- a/internal/types/case_insensitive_string.go
+++ b/internal/types/case_insensitive_string.go
@@ -1,0 +1,107 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ basetypes.StringTypable = CaseInsensitiveStringType{}
+var _ basetypes.StringValuable = CaseInsensitiveStringValue{}
+
+func CaseInsensitiveString(val string) CaseInsensitiveStringValue {
+	return CaseInsensitiveStringValue{
+		StringValue: types.StringValue(val),
+	}
+}
+
+type CaseInsensitiveStringType struct {
+	basetypes.StringType
+}
+
+func (t CaseInsensitiveStringType) Equal(o attr.Type) bool {
+	other, ok := o.(CaseInsensitiveStringType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t CaseInsensitiveStringType) String() string {
+	return "CaseInsensitiveStringType"
+}
+
+func (t CaseInsensitiveStringType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	value := CaseInsensitiveStringValue{
+		StringValue: in,
+	}
+
+	return value, nil
+}
+
+func (t CaseInsensitiveStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t CaseInsensitiveStringType) ValueType(ctx context.Context) attr.Value {
+	return CaseInsensitiveStringValue{}
+}
+
+type CaseInsensitiveStringValue struct {
+	basetypes.StringValue
+}
+
+func (v CaseInsensitiveStringValue) Equal(o attr.Value) bool {
+	other, ok := o.(CaseInsensitiveStringValue)
+	if !ok {
+		return false
+	}
+
+	return strings.EqualFold(v.ValueString(), other.ValueString())
+}
+
+func (v CaseInsensitiveStringValue) Type(ctx context.Context) attr.Type {
+	return CaseInsensitiveStringType{}
+}
+
+func (v CaseInsensitiveStringValue) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(CaseInsensitiveStringValue)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+
+	return strings.EqualFold(newValue.ValueString(), v.ValueString()), diags
+}

--- a/internal/types/case_insensitive_string.go
+++ b/internal/types/case_insensitive_string.go
@@ -80,7 +80,7 @@ func (v CaseInsensitiveStringValue) Equal(o attr.Value) bool {
 		return false
 	}
 
-	return strings.EqualFold(v.ValueString(), other.ValueString())
+	return v.StringValue.Equal(other.StringValue)
 }
 
 func (v CaseInsensitiveStringValue) Type(ctx context.Context) attr.Type {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Make account roles and namespace permissions case insensitive, by sending and receiving it in lowercase.

## Why?
<!-- Tell your future self why have you made these changes -->
The API currently returns capitalized roles/permissions, and we will be changing it to return lowercase roles/permissions as it should be case insensitive - and is when creating/updating users.

## Checklist