### PR TITLE
Update namespace_resource.go

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -159,7 +159,7 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				},
 			},
 			"regions": schema.ListAttribute{
-				Description: "The list of regions that this namespace is available in. If more than one region is specified, this namespace is \"global\" which is currently a preview feature with restricted access. Please reach out to Temporal support for more information on this feature.",
+				Description: "The list of regions that this namespace is available in. If more than one region is specified, this namespace is a \"Multi-region Namespace\", which is currently unsupported by the Terraform provider.",
 				ElementType: types.StringType,
 				Required:    true,
 				PlanModifiers: []planmodifier.List{


### PR DESCRIPTION
## What was changed
Changing the name from "global" to "multi-region" and mentioning that creation of multi-region namespaces is unsupported by the Terraform provider. See: [Multi-region Namespace documentation](https://docs.temporal.io/cloud/multi-region#management) for more information. 

## Why?
To make naming consistent and communicate to users of this provider what is supported and unsupported.