### PR TITLE
bug: Construct EncodedCAValue values directly from passed-in StringValue

### DIFF
--- a/internal/types/encoded_ca.go
+++ b/internal/types/encoded_ca.go
@@ -35,7 +35,7 @@ func (t EncodedCAType) Equal(o attr.Type) bool {
 }
 
 func (t EncodedCAType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
-	return EncodedCA(in.ValueString()), nil
+	return EncodedCAValue{in}, nil
 }
 
 func (t EncodedCAType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {

--- a/internal/types/encoded_ca_test.go
+++ b/internal/types/encoded_ca_test.go
@@ -1,6 +1,11 @@
 package types
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
 
 func TestCACertNormalization(t *testing.T) {
 	input := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJ5VENDQVZDZ0F3SUJBZ0lSQVdIa0MrNkpVZjNzOVRxNDNtZHAyemd3Q2dZSUtvWkl6ajBFQXdNd0V6RVIKTUE4R0ExVUVDaE1JZEdWdGNHOXlZV3d3SGhjTk1qTXdPREV3TURBd09UUTFXaGNOTWpRd09EQTVNREF4TURRMQpXakFUTVJFd0R3WURWUVFLRXdoMFpXMXdiM0poYkRCMk1CQUdCeXFHU000OUFnRUdCU3VCQkFBaUEySUFCQ3pRCjdEd3dHU1FLTTZacngzUXR3N0l1YmZ4aUozUlNYQ3FtY0doRWJGVmVvY3dBZEVnTVlsd1NsVWlXdERaVlIyZE0KWE05VVpMV0s0YUdHbkROUzVNaGN6NmliU0JTN093ZjR0UlpaQTlTcEZDak53MkhyYWFpVVZWK0VVZ3hvZTZObwpNR1l3RGdZRFZSMFBBUUgvQkFRREFnR0dNQThHQTFVZEV3RUIvd1FGTUFNQkFmOHdIUVlEVlIwT0JCWUVGRzROCjhsSVhxUUt4d1ZzL2l4VnpkRjZYR1ptK01DUUdBMVVkRVFRZE1CdUNHV05zYVdWdWRDNXliMjkwTG5SbGJYQnYKY21Gc0xsQjFWSE13Q2dZSUtvWkl6ajBFQXdNRFp3QXdaQUl3UkxmbTlTN3JLR2QzMEtkUXZVTWNPY0RKbG1Edwo2L29NNlVPSkZ4TGVHY3BZYmd4US9iRml6ZStZeDlROWtOZU1BakE3R2lGc2FpcGFLdFdIeTVNQ09DYXMzWlA2Cit0dExhWE5Yc3MzWjVXazV2aERRbnlFOEpSM3JQZVEyY0hYTGlBMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQoKCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlCeGpDQ0FVMmdBd0lCQWdJUkE3b2E2dnhqd3RvVHdFdjNhVnZoZWh3d0NnWUlLb1pJemowRUF3TXdFakVRCk1BNEdBMVVFQ2hNSGRHVnpkR2x1WnpBZUZ3MHlOREE0TURJeE5qUXhOVFJhRncweU5UQTRNREl4TmpReU5UUmEKTUJJeEVEQU9CZ05WQkFvVEIzUmxjM1JwYm1jd2RqQVFCZ2NxaGtqT1BRSUJCZ1VyZ1FRQUlnTmlBQVFDcVVqVApEUVVKN2t3a055K3hkc0l3TitEY2hvSmJjdWVQVk9FQTB5STR0M05jS3lDcDJSTjhkbVAzbjFidVhtVVFNODBFCmxsQVlNaDFHcEU3VW1oT1l2aVVXenFWajNmN0s1Qm8wT1QvUjFxcndxVldXL0ZvbU5vdVlxK3o4TUxTalp6QmwKTUE0R0ExVWREd0VCL3dRRUF3SUJoakFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQjBHQTFVZERnUVdCQlJPVS9FSAp4Q1dDWmNJemVTcnR0NGhIV1ozY3VUQWpCZ05WSFJFRUhEQWFnaGhqYkdsbGJuUXVjbTl2ZEM1MFpYTjBhVzVuCkxsRnNSRk13Q2dZSUtvWkl6ajBFQXdNRFp3QXdaQUl3VlJJSEFzbmExajdUZnllQWR4YUNpY2dNK1lHcTQwVTQKUTdjOThCVlg3M1h1NkFnWXlBVU41eGlvbkJZSklCU3FBakFMcWRkanFzVG9pN0hXMTd5STVuN1VzSUdabHdrcQoxMm9rQjFJR0JSbU9pOU1SSnhuVk0wZXhrWGFUaEhGZ0toYz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ=="
@@ -12,5 +17,47 @@ func TestCACertNormalization(t *testing.T) {
 
 	if normalized != expected {
 		t.Fatalf("unexpected normalized cert: %s", normalized)
+	}
+}
+
+func TestUnknownEncodedCAValue(t *testing.T) {
+	encodedCAValue, err := EncodedCAType{}.ValueFromString(context.Background(), basetypes.NewStringUnknown())
+	if err != nil {
+		t.Fatalf("failed to create EncodedCAValue: %v", err)
+		t.FailNow()
+	}
+
+	if !encodedCAValue.IsUnknown() {
+		t.Fatalf("unexpected value, should be unknown: %v", encodedCAValue)
+	}
+}
+
+func TestNullEncodedCAValue(t *testing.T) {
+	encodedCAValue, err := EncodedCAType{}.ValueFromString(context.Background(), basetypes.NewStringNull())
+	if err != nil {
+		t.Fatalf("failed to create EncodedCAValue: %v", err)
+		t.FailNow()
+	}
+
+	if !encodedCAValue.IsNull() {
+		t.Fatalf("unexpected value, should be null: %v", encodedCAValue)
+	}
+}
+
+func TestEncodedCAValue(t *testing.T) {
+	encodedCAValue, err := EncodedCAType{}.ValueFromString(context.Background(), basetypes.NewStringValue("some string"))
+	if err != nil {
+		t.Fatalf("failed to create EncodedCAValue: %v", err)
+		t.FailNow()
+	}
+
+	strVal, diags := encodedCAValue.ToStringValue(context.Background())
+	if diags.HasError() {
+		t.Fatalf("failed to convert EncodedCAValue to StringValue: %v", diags)
+		t.FailNow()
+	}
+
+	if strVal.ValueString() != "some string" {
+		t.Fatalf("unexpected string value: %s", strVal)
 	}
 }


### PR DESCRIPTION
This commit constructs an EncodedCAValue in `ValueFromString` directly from the passed-in StringValue instead of roundtripping through a string. By coercing the StringValue into a string, we unintentionally collapsed unknown and null strings into the empty string "", which causes Terraform to detect an invalid plan (an unknown property must remain unknown and not become any other value during the plan).