### PR TITLE
multi-region text changes

### DIFF
--- a/docs/data-sources/namespaces.md
+++ b/docs/data-sources/namespaces.md
@@ -60,7 +60,7 @@ Read-Only:
 - `id` (String) The unique identifier of the namespace across all Temporal Cloud tenants.
 - `limits` (Attributes) The limits set on the namespace currently. (see [below for nested schema](#nestedatt--namespaces--limits))
 - `name` (String) The name of the namespace.
-- `regions` (List of String) The list of regions that this namespace is available in. If more than one region is specified, this namespace is "global" which is currently a preview feature with restricted access. Please reach out to Temporal support for more information on this feature.
+- `regions` (List of String) The list of regions that this namespace is available in. If more than one region is specified, this namespace is a Multi-region Namespace, which is currently unsupported by the Terraform provider.
 - `retention_days` (Number) The number of days to retain workflow history. Any changes to the retention period will be applied to all new running workflows.
 - `state` (String) The current state of the namespace.
 

--- a/internal/provider/namespaces_datasource.go
+++ b/internal/provider/namespaces_datasource.go
@@ -143,7 +143,7 @@ func (d *namespacesDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 						},
 						"regions": schema.ListAttribute{
 							Computed:    true,
-							Description: "The list of regions that this namespace is available in. If more than one region is specified, this namespace is \"global\" which is currently a preview feature with restricted access. Please reach out to Temporal support for more information on this feature.",
+							Description: "The list of regions that this namespace is available in. If more than one region is specified, this namespace is a Multi-region Namespace, which is currently unsupported by the Terraform provider.",
 							ElementType: types.StringType,
 						},
 						"accepted_client_ca": schema.StringAttribute{

--- a/proto/go/temporal/api/cloud/namespace/v1/message.pb.go
+++ b/proto/go/temporal/api/cloud/namespace/v1/message.pb.go
@@ -236,9 +236,8 @@ type NamespaceSpec struct {
 	// The name is immutable. Once set, it cannot be changed.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// The ids of the regions where the namespace should be available.
-	// Specifying more than one region makes the namespace "global", which is currently a preview only feature with restricted access.
-	// Please reach out to Temporal support for more information on global namespaces.
-	// When provisioned the global namespace will be active on the first region in the list and passive on the rest.
+	// Specifying more than one region makes the namespace a "multi-region" namespace, which is currently unsupported by the Terraform provider.
+    // When provisioned, the multi-region namespace will be active on the first region in the list and passive on the rest.
 	// Number of supported regions is 2.
 	// The regions is immutable. Once set, it cannot be changed.
 	Regions []string `protobuf:"bytes,2,rep,name=regions,proto3" json:"regions,omitempty"`

--- a/proto/temporal/api/cloud/namespace/v1/message.proto
+++ b/proto/temporal/api/cloud/namespace/v1/message.proto
@@ -46,9 +46,8 @@ message NamespaceSpec {
     // The name is immutable. Once set, it cannot be changed.
     string name = 1;
     // The ids of the regions where the namespace should be available.
-    // Specifying more than one region makes the namespace "global", which is currently a preview only feature with restricted access.
-    // Please reach out to Temporal support for more information on global namespaces.
-    // When provisioned the global namespace will be active on the first region in the list and passive on the rest.
+    // Specifying more than one region makes the namespace a "multi-region" namespace, which is currently unsupported by the Terraform provider.
+    // When provisioned, the multi-region namespace will be active on the first region in the list and passive on the rest.
     // Number of supported regions is 2. 
     // The regions is immutable. Once set, it cannot be changed.
     repeated string regions = 2;


### PR DESCRIPTION
Removed references to "global" namespace, made clear that multi-region creation is not supported by Terraform

