### PR TITLE
Bump client api version to 2024-05-13-00

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -38,7 +38,7 @@ import (
 
 const TemporalCloudAPIVersionHeader = "temporal-cloud-api-version"
 
-var TemporalCloudAPIVersion = "2023-10-01-00"
+var TemporalCloudAPIVersion = "2024-05-13-00"
 
 // Client is a client for the Temporal Cloud API.
 type Client struct {

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -278,16 +278,19 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 			return
 		}
 	}
+	mtls := &namespacev1.MtlsAuthSpec{}
+	if plan.AcceptedClientCA.ValueString() != "" {
+		mtls.Enabled = true
+		mtls.AcceptedClientCa = plan.AcceptedClientCA.ValueString()
+		mtls.CertificateFilters = certFilters
+	}
 	svcResp, err := r.client.CloudService().CreateNamespace(ctx, &cloudservicev1.CreateNamespaceRequest{
 		Spec: &namespacev1.NamespaceSpec{
 			Name:          plan.Name.ValueString(),
 			Regions:       regions,
 			RetentionDays: int32(plan.RetentionDays.ValueInt64()),
-			MtlsAuth: &namespacev1.MtlsAuthSpec{
-				AcceptedClientCa:   plan.AcceptedClientCA.ValueString(),
-				CertificateFilters: certFilters,
-			},
-			CodecServer: codecServer,
+			MtlsAuth:      mtls,
+			CodecServer:   codecServer,
 		},
 	})
 	if err != nil {
@@ -360,16 +363,19 @@ func (r *namespaceResource) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	mtls := &namespacev1.MtlsAuthSpec{}
+	if plan.AcceptedClientCA.ValueString() != "" {
+		mtls.Enabled = true
+		mtls.AcceptedClientCa = plan.AcceptedClientCA.ValueString()
+		mtls.CertificateFilters = certFilters
+	}
 	svcResp, err := r.client.CloudService().UpdateNamespace(ctx, &cloudservicev1.UpdateNamespaceRequest{
 		Namespace: plan.ID.ValueString(),
 		Spec: &namespacev1.NamespaceSpec{
-			Name:          plan.Name.ValueString(),
-			Regions:       regions,
-			RetentionDays: int32(plan.RetentionDays.ValueInt64()),
-			MtlsAuth: &namespacev1.MtlsAuthSpec{
-				AcceptedClientCa:   plan.AcceptedClientCA.ValueString(),
-				CertificateFilters: certFilters,
-			},
+			Name:                   plan.Name.ValueString(),
+			Regions:                regions,
+			RetentionDays:          int32(plan.RetentionDays.ValueInt64()),
+			MtlsAuth:               mtls,
 			CodecServer:            codecServer,
 			CustomSearchAttributes: currentNs.GetNamespace().GetSpec().GetCustomSearchAttributes(),
 		},

--- a/internal/provider/namespace_search_attribute_resource_test.go
+++ b/internal/provider/namespace_search_attribute_resource_test.go
@@ -40,19 +40,19 @@ PEM
 resource "temporalcloud_namespace_search_attribute" "custom_search_attribute" {
   namespace_id = temporalcloud_namespace.terraform.id
   name         = "%s"
-  type         = "Text"
+  type         = "text"
 }
 
 resource "temporalcloud_namespace_search_attribute" "custom_search_attribute2" {
   namespace_id = temporalcloud_namespace.terraform.id
   name         = "CustomSearchAttribute2"
-  type         = "Text"
+  type         = "text"
 }
 
 resource "temporalcloud_namespace_search_attribute" "custom_search_attribute3" {
   namespace_id = temporalcloud_namespace.terraform.id
   name         = "CustomSearchAttribute3"
-  type         = "Text"
+  type         = "text"
 }`, name, saName)
 	}
 
@@ -102,7 +102,7 @@ PEM
 resource "temporalcloud_namespace_search_attribute" "custom_search_attribute" {
   namespace_id = temporalcloud_namespace.terraform.id
   name         = "%s"
-  type         = "Text"
+  type         = "text"
 }
 `, name, saName)
 	}
@@ -159,7 +159,7 @@ PEM
 resource "temporalcloud_namespace_search_attribute" "custom_search_attribute" {
   namespace_id = temporalcloud_namespace.terraform.id
   name         = "CustomSearchAttribute"
-  type         = "Text"
+  type         = "text"
 }
 `, name, retentionDays)
 	}


### PR DESCRIPTION
## What was changed
Bumped the client's api version to 2024-05-13-00

## Why?
To unblock other PRs to need features from the latest apis.

## Checklist

1. How was this tested:
`make testacc` passes.

2. Any docs updates needed?
No
