### PR TITLE
updated namespace_search_attribute_resource to make Type case insensitive

### DIFF
--- a/docs/resources/namespace_search_attribute.md
+++ b/docs/resources/namespace_search_attribute.md
@@ -58,7 +58,7 @@ resource "temporalcloud_namespace_search_attribute" "custom_search_attribute3" {
 
 - `name` (String) The name of the search attribute.
 - `namespace_id` (String) The ID of the namespace to which this search attribute belongs.
-- `type` (String) The type of the search attribute. Must be one of `Bool`, `Datetime`, `Double`, `Int`, `Keyword`, or `Text`.
+- `type` (String) The type of the search attribute. Must be one of `bool`, `datetime`, `double`, `int`, `keyword`, or `text`. (case-insensitive)
 
 ### Read-Only
 

--- a/internal/provider/apikey_resource_test.go
+++ b/internal/provider/apikey_resource_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	cloudservicev1 "go.temporal.io/api/cloud/cloudservice/v1"
-	"testing"
-	"time"
 )
 
 func createRandomApiKeyName() string {
@@ -116,11 +117,11 @@ resource "temporalcloud_apikey" "test" {
 	expiry_time = "%s"`, serviceAccountName, displayName, ownerType, getExpiryTime())
 
 		if !disable {
-			tmpConfig += fmt.Sprintf(`
-	disabled = false`)
+			tmpConfig += `
+	disabled = false`
 		} else {
-			tmpConfig += fmt.Sprintf(`
-	disabled = true`)
+			tmpConfig += `
+	disabled = true`
 		}
 
 		tmpConfig += `

--- a/internal/provider/namespace_search_attribute_resource.go
+++ b/internal/provider/namespace_search_attribute_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jpillora/maplock"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 
+	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
 	cloudservicev1 "go.temporal.io/api/cloud/cloudservice/v1"
 	namespacev1 "go.temporal.io/api/cloud/namespace/v1"
 )
@@ -25,10 +26,10 @@ type (
 	}
 
 	namespaceSearchAttributeModel struct {
-		ID          types.String `tfsdk:"id"`
-		NamespaceID types.String `tfsdk:"namespace_id"`
-		Name        types.String `tfsdk:"name"`
-		Type        types.String `tfsdk:"type"`
+		ID          types.String                             `tfsdk:"id"`
+		NamespaceID types.String                             `tfsdk:"namespace_id"`
+		Name        types.String                             `tfsdk:"name"`
+		Type        internaltypes.CaseInsensitiveStringValue `tfsdk:"type"`
 	}
 )
 
@@ -91,7 +92,8 @@ func (r *namespaceSearchAttributeResource) Schema(ctx context.Context, _ resourc
 				Required:    true,
 			},
 			"type": schema.StringAttribute{
-				Description: "The type of the search attribute. Must be one of `Bool`, `Datetime`, `Double`, `Int`, `Keyword`, or `Text`.",
+				CustomType:  internaltypes.CaseInsensitiveStringType{},
+				Description: "The type of the search attribute. Must be one of `bool`, `datetime`, `double`, `int`, `keyword`, or `text`. (case-insensitive)",
 				Required:    true,
 			},
 		},
@@ -312,7 +314,7 @@ func (m *namespaceSearchAttributeModel) updateFromSpec(spec *namespacev1.Namespa
 	// plan.ID is already set
 	// plan.NamespaceID is already set
 	// plan.Name is already set
-	m.Type = types.StringValue(searchAttrType)
+	m.Type = internaltypes.CaseInsensitiveString(searchAttrType)
 	return diags
 }
 

--- a/internal/provider/namespace_search_attribute_resource_test.go
+++ b/internal/provider/namespace_search_attribute_resource_test.go
@@ -46,7 +46,7 @@ resource "temporalcloud_namespace_search_attribute" "custom_search_attribute" {
 resource "temporalcloud_namespace_search_attribute" "custom_search_attribute2" {
   namespace_id = temporalcloud_namespace.terraform.id
   name         = "CustomSearchAttribute2"
-  type         = "text"
+  type         = "Text"
 }
 
 resource "temporalcloud_namespace_search_attribute" "custom_search_attribute3" {


### PR DESCRIPTION
… a case insensitive fied. Changed one of the tests to use an upper case Type value.

<!--- Note to EXTERNAL Contributors -->
Minor change to use the internal type case insensitive string for the Type field.  Used the same pattern found in user_resource for the account_accesss field

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes #136 

2. How was this tested:
tested with make testacc and by building a local provider and running local test cases based on the issue

3. Any docs updates needed?
no
