### PR TITLE
updated the grp address and added the mtls grp address to the namespa…

### DIFF
--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -171,7 +171,8 @@ Optional:
 
 Read-Only:
 
-- `grpc_address` (String) The gRPC endpoint for the namespace that clients can connect to.
+- `grpc_address` (String) The gRPC address for API key client connections (may be empty if API keys are disabled).
+- `mtls_grpc_address` (String) The gRPC address for mTLS client connections (may be empty if mTLS is disabled).
 - `web_address` (String) The address in the Temporal Cloud Web UI for the namespace
 
 ## Import

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -85,8 +85,9 @@ type (
 	}
 
 	endpointsModel struct {
-		WebAddress  types.String `tfsdk:"web_address"`
-		GrpcAddress types.String `tfsdk:"grpc_address"`
+		WebAddress      types.String `tfsdk:"web_address"`
+		GrpcAddress     types.String `tfsdk:"grpc_address"`
+		MtlsGrpcAddress types.String `tfsdk:"mtls_grpc_address"`
 	}
 )
 
@@ -109,8 +110,9 @@ var (
 	}
 
 	endpointsAttrs = map[string]attr.Type{
-		"web_address":  types.StringType,
-		"grpc_address": types.StringType,
+		"web_address":       types.StringType,
+		"grpc_address":      types.StringType,
+		"mtls_grpc_address": types.StringType,
 	}
 )
 
@@ -232,7 +234,11 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Description: "The endpoints for the namespace.",
 				Attributes: map[string]schema.Attribute{
 					"grpc_address": schema.StringAttribute{
-						Description: "The gRPC endpoint for the namespace that clients can connect to.",
+						Description: "The gRPC address for API key client connections (may be empty if API keys are disabled).",
+						Computed:    true,
+					},
+					"mtls_grpc_address": schema.StringAttribute{
+						Description: "The gRPC address for mTLS client connections (may be empty if mTLS is disabled).",
 						Computed:    true,
 					},
 					"web_address": schema.StringAttribute{
@@ -566,8 +572,9 @@ func updateModelFromSpec(ctx context.Context, diags diag.Diagnostics, state *nam
 	state.CodecServer = codecServerState
 
 	endpoints := &endpointsModel{
-		GrpcAddress: stringOrNull(ns.GetEndpoints().GetGrpcAddress()),
-		WebAddress:  stringOrNull(ns.GetEndpoints().GetWebAddress()),
+		GrpcAddress:     stringOrNull(ns.GetEndpoints().GetGrpcAddress()),
+		WebAddress:      stringOrNull(ns.GetEndpoints().GetWebAddress()),
+		MtlsGrpcAddress: stringOrNull(ns.GetEndpoints().GetMtlsGrpcAddress()),
 	}
 	endpointsState, objectDiags := types.ObjectValueFrom(ctx, endpointsAttrs, endpoints)
 	diags.Append(objectDiags...)


### PR DESCRIPTION
## What was changed
Updated the description for grpc_address and added a new mtls_grpc_address field as a part of the Namespace schema

## Why?
When we bumped the Cloud Ops API version to latest, we missed this update. 

## Checklist
<!--- add/delete as needed --->

1. Closes #140 

2. How was this tested:
ran full test suite locally
also reproduced and ran a test with a local build, output below

```
resource "temporalcloud_namespace" "namespace" {
...
    endpoints          = {
        mtls_grpc_address = "terraform144.ksfop.tmprl.cloud:7233"
        web_address       = "https://terraform144.ksfop.web.tmprl.cloud"
    }
 ...
}

```
3. Any docs updates needed?
generate will creat doc updates
