### PR TITLE
updated documentation for the API Key token field to indicate it's sensitive

### DIFF
--- a/docs/resources/apikey.md
+++ b/docs/resources/apikey.md
@@ -59,7 +59,7 @@ resource "temporalcloud_apikey" "global_apikey" {
 
 - `id` (String) The unique identifier of the API key.
 - `state` (String) The current state of the API key.
-- `token` (String, Sensitive) The token for the API key. This field will only be populated with the full key when creating an API key.
+- `token` (String, Sensitive) The token for the API key. This field is populated with the full key when creating an API key. To retrieve the value of this field, use an output.tf file and follow Terraform's guidance on working with sensitive fields.
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/resources/temporalcloud_apikey/output.tf
+++ b/examples/resources/temporalcloud_apikey/output.tf
@@ -1,0 +1,4 @@
+output "apikey_token" {
+  value     = temporalcloud_apikey.global_apikey.token
+  sensitive = true
+}

--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -107,7 +107,7 @@ func (r *apiKeyResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 				Required:    true,
 			},
 			"token": schema.StringAttribute{
-				Description: "The token for the API key. This field will only be populated with the full key when creating an API key.",
+				Description: "The token for the API key. This field is populated with the full key when creating an API key. To retrieve the value of this field, use an output.tf file and follow Terraform's guidance on working with sensitive fields.",
 				Computed:    true,
 				Sensitive:   true,
 				PlanModifiers: []planmodifier.String{


### PR DESCRIPTION
Updated the description and example for API Keys to provide guidance on working with the sensitive API Key Token field in Terraform

## What was changed
new output.tf in the api key examples folder
updated description for the api key token field

## Why?
To help users generate Api keys with TF

## Checklist

1. Closes #168 