### PR TITLE
Fix: Do not allow empty lists to be configured to keep state consistent between Create and Read

### DIFF
--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -124,7 +124,7 @@ resource "temporalcloud_namespace" "terraform3" {
 
 - `accepted_client_ca` (String) The Base64-encoded CA cert in PEM format that clients use when authenticating with Temporal Cloud. This is a required field when a Namespace uses mTLS authentication.
 - `api_key_auth` (Boolean) If true, Temporal Cloud will use API key authentication for this namespace. If false, mutual TLS (mTLS) authentication will be used.
-- `certificate_filters` (Attributes List) A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. (see [below for nested schema](#nestedatt--certificate_filters))
+- `certificate_filters` (Attributes List) A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. Empty lists are not allowed, omit the attribute instead. (see [below for nested schema](#nestedatt--certificate_filters))
 - `codec_server` (Attributes) A codec server is used by the Temporal Cloud UI to decode payloads for all users interacting with this namespace, even if the workflow history itself is encrypted. (see [below for nested schema](#nestedatt--codec_server))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -59,7 +59,7 @@ resource "temporalcloud_service_account" "namespace_admin" {
 
 ### Optional
 
-- `namespace_accesses` (Attributes List) The list of namespace accesses. (see [below for nested schema](#nestedatt--namespace_accesses))
+- `namespace_accesses` (Attributes List) The list of namespace accesses. Empty lists are not allowed, omit the attribute instead. (see [below for nested schema](#nestedatt--namespace_accesses))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -59,7 +59,7 @@ resource "temporalcloud_user" "namespace_admin" {
 
 ### Optional
 
-- `namespace_accesses` (Attributes List) The list of namespace accesses. (see [below for nested schema](#nestedatt--namespace_accesses))
+- `namespace_accesses` (Attributes List) The list of namespace accesses.Empty lists are not allowed, omit the attribute instead. (see [below for nested schema](#nestedatt--namespace_accesses))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -26,9 +26,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -183,7 +184,7 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Required:    true,
 			},
 			"certificate_filters": schema.ListNestedAttribute{
-				Description: "A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters.",
+				Description: "A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. Empty lists are not allowed, omit the attribute instead.",
 				Optional:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -26,6 +26,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -202,6 +204,9 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 							Optional:    true,
 						},
 					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 				},
 			},
 			"api_key_auth": schema.BoolAttribute{

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -186,7 +186,6 @@ func (r *serviceAccountResource) Create(ctx context.Context, req resource.Create
 			},
 		},
 	})
-
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create Service Account", err.Error())
 		return

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -133,6 +134,9 @@ func (r *serviceAccountResource) Schema(ctx context.Context, _ resource.SchemaRe
 							},
 						},
 					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 				},
 			},
 		},

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -117,7 +118,7 @@ func (r *serviceAccountResource) Schema(ctx context.Context, _ resource.SchemaRe
 				},
 			},
 			"namespace_accesses": schema.ListNestedAttribute{
-				Description: "The list of namespace accesses.",
+				Description: "The list of namespace accesses. Empty lists are not allowed, omit the attribute instead.",
 				Optional:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -115,7 +116,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"namespace_accesses": schema.ListNestedAttribute{
-				Description: "The list of namespace accesses.",
+				Description: "The list of namespace accesses.Empty lists are not allowed, omit the attribute instead.",
 				Optional:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,8 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -133,6 +133,9 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 							},
 						},
 					},
+				},
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 				},
 			},
 		},

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/provider/enums"
 	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"


### PR DESCRIPTION
## What was changed
This change adds a minimum length requirement for various list attributes. 

## Why?
The temporal cloud API doesn't differentiate between empty lists and null. This causes the terraform state to be inconsistent between Create and Read operations if an empty list `[]` is configured.

Additionally setting an empty list already doesn't work because the provider is erroneously setting it back to null in the state and results in this error from #115 and a tainted resource:

```
When applying changes to temporalcloud_user.user, provider "provider["registry.terraform.io/temporalio/temporalcloud"]" produced an unexpected new value: .namespace_accesses: 
was cty.ListValEmpty(cty.Object(map[string]cty.Type{"namespace_id":cty.String, "permission":cty.String})), but now null.
```

## Checklist
<!--- add/delete as needed --->

Closes #115 

2. How was this tested:
Manually tested and added new integration tests 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
