### PR TITLE
Increase the jitter on the retry interceptor.

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -60,12 +60,16 @@ func NewConnectionWithAPIKey(addrStr string, allowInsecure bool, apiKey string) 
 		HostPort:    addrStr,
 		ConnectionOptions: client.ConnectionOptions{
 			DialOptions: []grpc.DialOption{
+				// Make sure to keep this a chain interceptor and make this a inner interceptor.
+				// This will make sure to exercise this retry before the retry interceptor in the SDK.
+				// TODO (abhinav): Move this retry interceptor to the SDK.
 				grpc.WithChainUnaryInterceptor(
 					grpcretry.UnaryClientInterceptor(
+						// max backoff = 64s (+/- 32s jitter)
 						grpcretry.WithBackoff(
-							grpcretry.BackoffExponentialWithJitter(250*time.Millisecond, 0.1),
+							grpcretry.BackoffExponentialWithJitter(500*time.Millisecond, 0.5),
 						),
-						grpcretry.WithMax(5),
+						grpcretry.WithMax(7),
 					),
 				),
 			},


### PR DESCRIPTION
## What was changed
Increased the jitter on the retry interceptor from 0.1 to 0.5. 
Increased the scalar on the retry interceptor from 0.25s to 0.5s.
Increased the max tries from 5 to 7.

With these changes the max retry window will be 32s to 96s.

## Why?
This is to address terraform running into ResourceExhausted errors by making the retry logic to more aggressively backoff and try longer.
