### PR TITLE
Service Account Resource: improve handling of diagnostics object

### DIFF
--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -161,7 +161,8 @@ func (r *serviceAccountResource) Create(ctx context.Context, req resource.Create
 	ctx, cancel := context.WithTimeout(ctx, createTimeout)
 	defer cancel()
 
-	namespaceAccesses := getNamespaceAccessesFromServiceAccountModel(ctx, resp.Diagnostics, &plan)
+	namespaceAccesses, d := getNamespaceAccessesFromServiceAccountModel(ctx, &plan)
+	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -236,7 +237,8 @@ func (r *serviceAccountResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	namespaceAccesses := getNamespaceAccessesFromServiceAccountModel(ctx, resp.Diagnostics, &plan)
+	namespaceAccesses, d := getNamespaceAccessesFromServiceAccountModel(ctx, &plan)
+	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -334,15 +336,16 @@ func (r *serviceAccountResource) ImportState(ctx context.Context, req resource.I
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func getNamespaceAccessesFromServiceAccountModel(ctx context.Context, diags diag.Diagnostics, model *serviceAccountResourceModel) map[string]*identityv1.NamespaceAccess {
+func getNamespaceAccessesFromServiceAccountModel(ctx context.Context, model *serviceAccountResourceModel) (map[string]*identityv1.NamespaceAccess, diag.Diagnostics) {
+	var diags diag.Diagnostics
 	elements := make([]types.Object, 0, len(model.NamespaceAccesses.Elements()))
 	diags.Append(model.NamespaceAccesses.ElementsAs(ctx, &elements, false)...)
 	if diags.HasError() {
-		return nil
+		return nil, diags
 	}
 
 	if len(elements) == 0 {
-		return nil
+		return nil, diags
 	}
 
 	namespaceAccesses := make(map[string]*identityv1.NamespaceAccess, len(elements))
@@ -350,19 +353,19 @@ func getNamespaceAccessesFromServiceAccountModel(ctx context.Context, diags diag
 		var model serviceAccountNamespaceAccessModel
 		diags.Append(access.As(ctx, &model, basetypes.ObjectAsOptions{})...)
 		if diags.HasError() {
-			return nil
+			return nil, diags
 		}
 		persmission, err := enums.ToNamespaceAccessPermission(model.Permission.ValueString())
 		if err != nil {
 			diags.AddError("Failed to convert namespace access permission", err.Error())
-			return nil
+			return nil, diags
 		}
 		namespaceAccesses[model.NamespaceID.ValueString()] = &identityv1.NamespaceAccess{
 			Permission: persmission,
 		}
 	}
 
-	return namespaceAccesses
+	return namespaceAccesses, diags
 }
 
 func updateServiceAccountModelFromSpec(ctx context.Context, state *serviceAccountResourceModel, serviceAccount *identityv1.ServiceAccount) diag.Diagnostics {


### PR DESCRIPTION
## What was changed
This PR improves the handling of the diag.Diagnostics in the service account resource. Prior to this change errors added in a helper function were not being correctly bubbled up to terraform.
