### PR TITLE
API Keys: Do not allow importing

### DIFF
--- a/docs/resources/apikey.md
+++ b/docs/resources/apikey.md
@@ -68,16 +68,3 @@ Optional:
 
 - `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 - `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
-
-## Import
-
-Import is supported using the following syntax:
-
-```shell
-# API Keys can be imported to incorporate existing API Keys into your Terraform pipeline. 
-# To import an API Key, you need
-# - a resource configuration in your Terraform configuration file/module to accept the imported API Key. In the example below, the placeholder is "temporalcloud_apikey" "tfapikey"
-# - the API Key's ID, which is found when clicking into an API Key in the Temporal Cloud UI. In the example below, this is zJV5zQ3IhsAbw75dAkVNEMsAd3a5AemC
-
-terraform import temporalcloud_apikey.tfapikey zJV5zQ3IhsAbw75dAkVNEMsAd3a5AemC
-```

--- a/examples/resources/temporalcloud_apikey/import.sh
+++ b/examples/resources/temporalcloud_apikey/import.sh
@@ -1,6 +1,0 @@
-# API Keys can be imported to incorporate existing API Keys into your Terraform pipeline. 
-# To import an API Key, you need
-# - a resource configuration in your Terraform configuration file/module to accept the imported API Key. In the example below, the placeholder is "temporalcloud_apikey" "tfapikey"
-# - the API Key's ID, which is found when clicking into an API Key in the Temporal Cloud UI. In the example below, this is zJV5zQ3IhsAbw75dAkVNEMsAd3a5AemC
-
-terraform import temporalcloud_apikey.tfapikey zJV5zQ3IhsAbw75dAkVNEMsAd3a5AemC

--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -39,9 +38,8 @@ type (
 )
 
 var (
-	_ resource.Resource                = (*apiKeyResource)(nil)
-	_ resource.ResourceWithConfigure   = (*apiKeyResource)(nil)
-	_ resource.ResourceWithImportState = (*apiKeyResource)(nil)
+	_ resource.Resource              = (*apiKeyResource)(nil)
+	_ resource.ResourceWithConfigure = (*apiKeyResource)(nil)
 )
 
 func NewApiKeyResource() resource.Resource {
@@ -357,10 +355,6 @@ func (r *apiKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 }
 
-func (r *apiKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-}
-
 func updateApiKeyModelFromSpec(state *apiKeyResourceModel, apikey *identityv1.ApiKey) error {
 	state.ID = types.StringValue(apikey.GetId())
 	stateStr, err := enums.FromResourceState(apikey.GetState())
@@ -379,5 +373,6 @@ func updateApiKeyModelFromSpec(state *apiKeyResourceModel, apikey *identityv1.Ap
 		state.Description = types.StringValue(apikey.GetSpec().GetDescription())
 	}
 	state.ExpiryTime = types.StringValue(apikey.GetSpec().GetExpiryTime().AsTime().Format(time.RFC3339))
+
 	return nil
 }

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -187,7 +187,7 @@ PEM
 			{
 				ImportState:       true,
 				ImportStateVerify: true,
-				ResourceName:      "temporalcloud_namespace.terraform",
+				ResourceName:      "temporalcloud_namespace.test",
 			},
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -85,6 +85,11 @@ PEM
 			{
 				Config: config(name, 14),
 			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_namespace.terraform",
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})
@@ -117,6 +122,11 @@ resource "temporalcloud_namespace" "terraform" {
 			},
 			{
 				Config: config(name, 14),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_namespace.terraform",
 			},
 			// Delete testing automatically occurs in TestCase
 		},
@@ -173,6 +183,11 @@ PEM
 			},
 			{
 				Config: config(name, 14),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_namespace.terraform",
 			},
 			// Delete testing automatically occurs in TestCase
 		},
@@ -306,6 +321,11 @@ PEM
 					}
 					return nil
 				},
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_namespace.test",
 			},
 			{
 				// remove codec server

--- a/internal/provider/service_account_resource_test.go
+++ b/internal/provider/service_account_resource_test.go
@@ -65,13 +65,18 @@ resource "temporalcloud_service_account" "terraform" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config(name, "Read"),
+				Config: config(name, "read"),
 			},
 			{
-				Config: config(name, "Developer"),
+				Config: config(name, "developer"),
 			},
 			{
-				Config: config(name, "Admin"),
+				Config: config(name, "admin"),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_service_account.terraform",
 			},
 		},
 	})
@@ -149,8 +154,8 @@ resource "temporalcloud_service_account" "terraform" {
 				Config: config(configArgs{
 					Name:          name,
 					NamespaceName: randomString(),
-					NamespacePerm: "Write",
-					AccountPerm:   "Read",
+					NamespacePerm: "write",
+					AccountPerm:   "read",
 				}),
 				Check: func(state *terraform.State) error {
 					id := state.RootModule().Resources["temporalcloud_service_account.terraform"].Primary.Attributes["id"]
@@ -181,6 +186,11 @@ resource "temporalcloud_service_account" "terraform" {
 					}
 					return nil
 				},
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_service_account.terraform",
 			},
 		},
 	})

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -70,13 +70,18 @@ resource "temporalcloud_user" "terraform" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: config(emailAddr, "Read"),
+				Config: config(emailAddr, "read"),
 			},
 			{
-				Config: config(emailAddr, "Developer"),
+				Config: config(emailAddr, "developer"),
 			},
 			{
-				Config: config(emailAddr, "Admin"),
+				Config: config(emailAddr, "admin"),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_user.terraform",
 			},
 		},
 	})
@@ -154,8 +159,8 @@ resource "temporalcloud_user" "terraform" {
 				Config: config(configArgs{
 					Email:         emailAddr,
 					NamespaceName: randomString(),
-					NamespacePerm: "Write",
-					AccountPerm:   "Read",
+					NamespacePerm: "write",
+					AccountPerm:   "read",
 				}),
 				Check: func(state *terraform.State) error {
 					id := state.RootModule().Resources["temporalcloud_user.terraform"].Primary.Attributes["id"]
@@ -186,6 +191,11 @@ resource "temporalcloud_user" "terraform" {
 					}
 					return nil
 				},
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_user.terraform",
 			},
 		},
 	})


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR disables the ability to import API Keys from the Cloud Ops API into Terraform State.

## Why?
The provider currently supports importing of API Keys. However the Cloud Ops API will only return the API key token on initial creation and so any attempt at importing will produce an incomplete state and an invalid plan:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # temporalcloud_apikey.global_apikey will be updated in-place
  ~ resource "temporalcloud_apikey" "global_apikey" {
        id           = "..."
      + token        = (sensitive value)
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
