### PR TITLE
API Key: refresh Disabled state

### DIFF
--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -126,6 +127,8 @@ func (r *apiKeyResource) Schema(ctx context.Context, _ resource.SchemaRequest, r
 			"disabled": schema.BoolAttribute{
 				Description: "Whether the API key is disabled.",
 				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -373,6 +376,7 @@ func updateApiKeyModelFromSpec(state *apiKeyResourceModel, apikey *identityv1.Ap
 		state.Description = types.StringValue(apikey.GetSpec().GetDescription())
 	}
 	state.ExpiryTime = types.StringValue(apikey.GetSpec().GetExpiryTime().AsTime().Format(time.RFC3339))
+	state.Disabled = types.BoolValue(apikey.GetSpec().GetDisabled())
 
 	return nil
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR correctly refreshes the Disabled state from the API on Read.

## Why?
Previously this field was being omitted and therefore we couldn't detect drift on the `Disabled` field. 

## Checklist
<!--- add/delete as needed --->

1. Closes n/a

2. How was this tested:
Manually tested the upgrade from unset case 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
