### PR TITLE
Docs: Use lower case role names

### DIFF
--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -34,12 +34,12 @@ resource "temporalcloud_namespace" "namespace" {
 
 resource "temporalcloud_service_account" "global_service_account" {
   name           = "admin"
-  account_access = "Admin"
+  account_access = "admin"
 }
 
 resource "temporalcloud_service_account" "namespace_admin" {
   name           = "developer"
-  account_access = "Developer"
+  account_access = "developer"
   namespace_accesses = [
     {
       namespace_id = temporalcloud_namespace.namespace.id

--- a/examples/resources/temporalcloud_service_account/resource.tf
+++ b/examples/resources/temporalcloud_service_account/resource.tf
@@ -19,12 +19,12 @@ resource "temporalcloud_namespace" "namespace" {
 
 resource "temporalcloud_service_account" "global_service_account" {
   name           = "admin"
-  account_access = "Admin"
+  account_access = "admin"
 }
 
 resource "temporalcloud_service_account" "namespace_admin" {
   name           = "developer"
-  account_access = "Developer"
+  account_access = "developer"
   namespace_accesses = [
     {
       namespace_id = temporalcloud_namespace.namespace.id


### PR DESCRIPTION
## What was changed
Small docs update to encourage usage of lowercase role names

