### PR TITLE
Update Access description strings

### DIFF
--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -54,7 +54,7 @@ resource "temporalcloud_service_account" "namespace_admin" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of [admin, developer, read] (case-insensitive).
+- `account_access` (String) The role on the account. Must be one of admin, developer, or read (case-insensitive).
 - `name` (String) The name associated with the service account.
 
 ### Optional
@@ -73,7 +73,7 @@ resource "temporalcloud_service_account" "namespace_admin" {
 Required:
 
 - `namespace_id` (String) The namespace to assign permissions to.
-- `permission` (String) The permission to assign. Must be one of [admin, write, read] (case-insensitive)
+- `permission` (String) The permission to assign. Must be one of admin, write, or read (case-insensitive)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -54,7 +54,7 @@ resource "temporalcloud_user" "namespace_admin" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of [owner, admin, developer, read] (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.
+- `account_access` (String) The role on the account. Must be one of owner, admin, developer, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.
 - `email` (String) The email address for the user.
 
 ### Optional
@@ -73,7 +73,7 @@ resource "temporalcloud_user" "namespace_admin" {
 Required:
 
 - `namespace_id` (String) The namespace to assign permissions to.
-- `permission` (String) The permission to assign. Must be one of [admin, write, read] (case-insensitive)
+- `permission` (String) The permission to assign. Must be one of admin, write, or read (case-insensitive)
 
 
 <a id="nestedblock--timeouts"></a>

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -111,7 +111,7 @@ func (r *serviceAccountResource) Schema(ctx context.Context, _ resource.SchemaRe
 			},
 			"account_access": schema.StringAttribute{
 				CustomType:  internaltypes.CaseInsensitiveStringType{},
-				Description: "The role on the account. Must be one of [admin, developer, read] (case-insensitive).",
+				Description: "The role on the account. Must be one of admin, developer, or read (case-insensitive).",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive("admin", "developer", "read"),
@@ -128,7 +128,7 @@ func (r *serviceAccountResource) Schema(ctx context.Context, _ resource.SchemaRe
 						},
 						"permission": schema.StringAttribute{
 							CustomType:  internaltypes.CaseInsensitiveStringType{},
-							Description: "The permission to assign. Must be one of [admin, write, read] (case-insensitive)",
+							Description: "The permission to assign. Must be one of admin, write, or read (case-insensitive)",
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive("admin", "write", "read"),

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -110,7 +110,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 			},
 			"account_access": schema.StringAttribute{
 				CustomType:  internaltypes.CaseInsensitiveStringType{},
-				Description: "The role on the account. Must be one of [owner, admin, developer, read] (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.",
+				Description: "The role on the account. Must be one of owner, admin, developer, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive("owner", "admin", "developer", "read"),
@@ -127,7 +127,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 						},
 						"permission": schema.StringAttribute{
 							CustomType:  internaltypes.CaseInsensitiveStringType{},
-							Description: "The permission to assign. Must be one of [admin, write, read] (case-insensitive)",
+							Description: "The permission to assign. Must be one of admin, write, or read (case-insensitive)",
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.OneOfCaseInsensitive("admin", "write", "read"),


### PR DESCRIPTION
## What was changed
Currently the terraform docs are interpreting the existing description string as having a markdown link at the end:

<img width="644" alt="image" src="https://github.com/user-attachments/assets/4b8efbcb-eb4d-4094-8480-63f000c1e540">

This PR removes that ambiguity. 