### PR TITLE
Namespaces: Ignore order changes on region list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.2
 require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
-	github.com/hashicorp/terraform-plugin-framework v1.13.0
+	github.com/hashicorp/terraform-plugin-framework v1.13.1-0.20241206224247-37749fd91ce9
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.15.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/hashicorp/terraform-plugin-docs v0.20.1 h1:Fq7E/HrU8kuZu3hNliZGwloFWS
 github.com/hashicorp/terraform-plugin-docs v0.20.1/go.mod h1:Yz6HoK7/EgzSrHPB9J/lWFzwl9/xep2OPnc5jaJDV90=
 github.com/hashicorp/terraform-plugin-framework v1.13.0 h1:8OTG4+oZUfKgnfTdPTJwZ532Bh2BobF4H+yBiYJ/scw=
 github.com/hashicorp/terraform-plugin-framework v1.13.0/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
+github.com/hashicorp/terraform-plugin-framework v1.13.1-0.20241206224247-37749fd91ce9 h1:gge3yWYXUq5Je3DtU+SC18VRNQhE+z9pRLiXlGZsHJg=
+github.com/hashicorp/terraform-plugin-framework v1.13.1-0.20241206224247-37749fd91ce9/go.mod h1:j64rwMGpgM3NYXTKuxrCnyubQb/4VKldEKlcG8cvmjU=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
 github.com/hashicorp/terraform-plugin-framework-validators v0.15.0 h1:RXMmu7JgpFjnI1a5QjMCBb11usrW2OtAG+iOTIj5c9Y=

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -62,15 +62,15 @@ type (
 	}
 
 	namespaceResourceModel struct {
-		ID                 types.String                 `tfsdk:"id"`
-		Name               types.String                 `tfsdk:"name"`
-		Regions            types.List                   `tfsdk:"regions"`
-		AcceptedClientCA   internaltypes.EncodedCAValue `tfsdk:"accepted_client_ca"`
-		RetentionDays      types.Int64                  `tfsdk:"retention_days"`
-		CertificateFilters types.List                   `tfsdk:"certificate_filters"`
-		ApiKeyAuth         types.Bool                   `tfsdk:"api_key_auth"`
-		CodecServer        types.Object                 `tfsdk:"codec_server"`
-		Endpoints          types.Object                 `tfsdk:"endpoints"`
+		ID                 types.String                           `tfsdk:"id"`
+		Name               types.String                           `tfsdk:"name"`
+		Regions            internaltypes.UnorderedStringListValue `tfsdk:"regions"`
+		AcceptedClientCA   internaltypes.EncodedCAValue           `tfsdk:"accepted_client_ca"`
+		RetentionDays      types.Int64                            `tfsdk:"retention_days"`
+		CertificateFilters types.List                             `tfsdk:"certificate_filters"`
+		ApiKeyAuth         types.Bool                             `tfsdk:"api_key_auth"`
+		CodecServer        types.Object                           `tfsdk:"codec_server"`
+		Endpoints          types.Object                           `tfsdk:"endpoints"`
 
 		Timeouts timeouts.Value `tfsdk:"timeouts"`
 	}
@@ -170,6 +170,9 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Description: "The list of regions that this namespace is available in. If more than one region is specified, this namespace is a \"Multi-region Namespace\", which is currently unsupported by the Terraform provider.",
 				ElementType: types.StringType,
 				Required:    true,
+				CustomType: internaltypes.UnorderedStringListType{
+					ListType: basetypes.ListType{ElemType: basetypes.StringType{}},
+				},
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
 				},
@@ -561,6 +564,9 @@ func updateModelFromSpec(ctx context.Context, state *namespaceResourceModel, ns 
 	if diags.HasError() {
 		return diags
 	}
+	planRegionsUnordered := internaltypes.UnorderedStringListValue{
+		ListValue: planRegions,
+	}
 
 	certificateFilter := types.ListNull(types.ObjectType{AttrTypes: namespaceCertificateFilterAttrs})
 	if len(ns.GetSpec().GetMtlsAuth().GetCertificateFilters()) > 0 {
@@ -634,7 +640,7 @@ func updateModelFromSpec(ctx context.Context, state *namespaceResourceModel, ns 
 	}
 
 	state.Endpoints = endpointsState
-	state.Regions = planRegions
+	state.Regions = planRegionsUnordered
 	state.CertificateFilters = certificateFilter
 	state.RetentionDays = types.Int64Value(int64(ns.GetSpec().GetRetentionDays()))
 

--- a/internal/types/unordered_string_list.go
+++ b/internal/types/unordered_string_list.go
@@ -127,8 +127,8 @@ func (v UnorderedStringListValue) ListSemanticEquals(ctx context.Context, newVal
 		return false, diags
 	}
 
-	newValueArray := make([]string, 0, len(v.ListValue.Elements()))
-	diags.Append(v.ElementsAs(ctx, &newValueArray, false)...)
+	newValueArray := make([]string, 0, len(newValue.Elements()))
+	diags.Append(newValue.ElementsAs(ctx, &newValueArray, false)...)
 	if diags.HasError() {
 		return false, diags
 	}

--- a/internal/types/unordered_string_list.go
+++ b/internal/types/unordered_string_list.go
@@ -1,0 +1,146 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"slices"
+)
+
+var _ basetypes.ListTypable = UnorderedStringListType{}
+var _ basetypes.ListValuableWithSemanticEquals = UnorderedStringListValue{}
+
+type UnorderedStringListType struct {
+	basetypes.ListType
+}
+
+func (t UnorderedStringListType) WithElementType(typ attr.Type) attr.TypeWithElementType {
+	return UnorderedStringListType{
+		ListType: t.ListType.WithElementType(typ).(basetypes.ListType),
+	}
+}
+
+func (t UnorderedStringListType) Equal(o attr.Type) bool {
+	other, ok := o.(UnorderedStringListType)
+	if !ok {
+		return false
+	}
+
+	return t.ListType.Equal(other.ListType)
+}
+
+func (t UnorderedStringListType) String() string {
+	return "UnorderedStringListType"
+}
+
+func (t UnorderedStringListType) ValueFromList(ctx context.Context, in basetypes.ListValue) (basetypes.ListValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if _, ok := in.ElementType(ctx).(basetypes.StringTypable); !ok {
+		diags.AddError(
+			"Unexpected List Element Type Error",
+			"An unexpected value type was received while using custom UnorderedStringListType. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", basetypes.StringType{})+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", in.ElementType(ctx)),
+		)
+		return nil, diags
+	}
+
+	value := UnorderedStringListValue{
+		ListValue: in,
+	}
+
+	return value, nil
+}
+
+func (t UnorderedStringListType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.ListType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	listValue, ok := attrValue.(basetypes.ListValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	listValuable, diags := t.ValueFromList(ctx, listValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ListValue to ListValuable: %v", diags)
+	}
+
+	return listValuable, nil
+}
+
+func (t UnorderedStringListType) ValueType(ctx context.Context) attr.Value {
+	return UnorderedStringListValue{
+		ListValue: t.ListType.ValueType(ctx).(basetypes.ListValue),
+	}
+}
+
+type UnorderedStringListValue struct {
+	basetypes.ListValue
+}
+
+func (v UnorderedStringListValue) Equal(o attr.Value) bool {
+	other, ok := o.(UnorderedStringListValue)
+	if !ok {
+		return false
+	}
+
+	return v.ListValue.Equal(other.ListValue)
+}
+
+func (v UnorderedStringListValue) Type(ctx context.Context) attr.Type {
+	return UnorderedStringListType{
+		ListType: basetypes.ListType{}.WithElementType(v.ElementType(ctx)).(basetypes.ListType),
+	}
+}
+
+func (v UnorderedStringListValue) ListSemanticEquals(ctx context.Context, newValuable basetypes.ListValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(UnorderedStringListValue)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+
+	// If they are not the same length then return early
+	if len(v.ListValue.Elements()) != len(newValue.ListValue.Elements()) {
+		return false, diags
+	}
+
+	currentValueArray := make([]string, 0, len(v.ListValue.Elements()))
+	diags.Append(v.ElementsAs(ctx, &currentValueArray, false)...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	newValueArray := make([]string, 0, len(v.ListValue.Elements()))
+	diags.Append(v.ElementsAs(ctx, &newValueArray, false)...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	slices.Sort(currentValueArray)
+	slices.Sort(newValueArray)
+
+	for i, value := range currentValueArray {
+		if newValueArray[i] != value {
+			return false, diags
+		}
+	}
+
+	return true, diags
+}

--- a/internal/types/unordered_string_list_test.go
+++ b/internal/types/unordered_string_list_test.go
@@ -67,10 +67,10 @@ func TestUnorderedStringListValue_ListSemanticEquals(t *testing.T) {
 				t.Fatal(listDiags.Errors())
 			}
 
-			listAUnorderd := UnorderedStringListValue{ListValue: listA}
-			listBUnorderd := UnorderedStringListValue{ListValue: listB}
+			listAUnordered := UnorderedStringListValue{ListValue: listA}
+			listBUnordered := UnorderedStringListValue{ListValue: listB}
 
-			equal, diags := listAUnorderd.ListSemanticEquals(context.Background(), listBUnorderd)
+			equal, diags := listAUnordered.ListSemanticEquals(context.Background(), listBUnordered)
 			if diags.HasError() {
 				t.Fatal(diags.Errors())
 			}

--- a/internal/types/unordered_string_list_test.go
+++ b/internal/types/unordered_string_list_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"testing"
+)
+
+func TestUnorderedStringListValue_ListSemanticEquals(t *testing.T) {
+	testCases := []struct {
+		ListA         []string
+		ListB         []string
+		ExpectedEqual bool
+	}{
+		{
+			ListA:         nil,
+			ListB:         nil,
+			ExpectedEqual: true,
+		},
+		{
+			ListA:         []string{},
+			ListB:         []string{},
+			ExpectedEqual: true,
+		},
+		{
+			ListA:         []string{""},
+			ListB:         []string{""},
+			ExpectedEqual: true,
+		},
+		{
+			ListA:         []string{"test-2"},
+			ListB:         []string{"test-1"},
+			ExpectedEqual: false,
+		},
+		{
+			ListA:         []string{"test-1"},
+			ListB:         []string{"test-2", "test-3", "test-1"},
+			ExpectedEqual: false,
+		},
+		{
+			ListA:         []string{"test-1", "test-2", "test-3"},
+			ListB:         []string{"test-2"},
+			ExpectedEqual: false,
+		},
+		{
+			ListA:         []string{"test-1", "test-2", "test-3"},
+			ListB:         []string{"test-2", "test-3", "test-1"},
+			ExpectedEqual: true,
+		},
+		{
+			ListA:         []string{"test-1", "test-2", "test-3"},
+			ListB:         []string{"test-1", "test-2", "test-3"},
+			ExpectedEqual: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test-case-%d", i), func(t *testing.T) {
+			listA, listDiags := types.ListValueFrom(context.Background(), types.StringType, tc.ListA)
+			if listDiags.HasError() {
+				t.Fatal(listDiags.Errors())
+			}
+
+			listB, listDiags := types.ListValueFrom(context.Background(), types.StringType, tc.ListB)
+			if listDiags.HasError() {
+				t.Fatal(listDiags.Errors())
+			}
+
+			listAUnorderd := UnorderedStringListValue{ListValue: listA}
+			listBUnorderd := UnorderedStringListValue{ListValue: listB}
+
+			equal, diags := listAUnorderd.ListSemanticEquals(context.Background(), listBUnorderd)
+			if diags.HasError() {
+				t.Fatal(diags.Errors())
+			}
+
+			if equal != tc.ExpectedEqual {
+				t.Fatalf("Expected %v, got %v", tc.ExpectedEqual, equal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Avoid recreating a namespace if the order of its regions changes in the API response. 

Fixes #209 

## Why?
Multi-region Namespaces could change the order of the regions in the list when a fail-over happens. In that case we don't want to consider the namespace in need of replacement.

## Checklist
<!--- add/delete as needed --->

1. Closes #209 
2. How was this tested:
Manually with MRNs and manual failovers
Added unit tests for new unordered list type.

3. Any docs updates needed?
No
