### PR TITLE
Add `allowed_account_id` provider configuration parameter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,9 @@ provider "temporalcloud" {
 
   # Also can be set by environment variable `TEMPORAL_CLOUD_ALLOW_INSECURE`
   allow_insecure = false
+
+  # Also can be set by environment variable `TEMPORAL_CLOUD_ALLOWED_ACCOUNT_ID`
+  allowed_account_id = "my-temporalcloud-account-id"
 }
 ```
 
@@ -58,5 +61,6 @@ provider "temporalcloud" {
 ### Optional
 
 - `allow_insecure` (Boolean) If set to True, it allows for an insecure connection to the Temporal Cloud API. This should never be set to 'true' in production and defaults to false.
+- `allowed_account_id` (String) The ID of the account to operate on. Prevents accidental mutation of accounts other than that provided.
 - `api_key` (String, Sensitive) The API key for Temporal Cloud. See [this documentation](https://docs.temporal.io/cloud/api-keys) for information on how to obtain an API key.
 - `endpoint` (String) The endpoint for the Temporal Cloud API. Defaults to `saas-api.tmprl.cloud:443`.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -15,4 +15,7 @@ provider "temporalcloud" {
 
   # Also can be set by environment variable `TEMPORAL_CLOUD_ALLOW_INSECURE`
   allow_insecure = false
+
+  # Also can be set by environment variable `TEMPORAL_CLOUD_ALLOWED_ACCOUNT_ID`
+  allowed_account_id = "my-temporalcloud-account-id"
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -73,7 +73,7 @@ in version control. We recommend passing credentials to this provider via enviro
 				Optional:    true,
 			},
 			"allowed_account_id": schema.StringAttribute{
-				Description: "The ID of the account to operate on. Prevents accidental mutation of accounts other than that listed",
+				Description: "The ID of the account to operate on. Prevents accidental mutation of accounts other than that provided.",
 				Optional:    true,
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.temporal.io/api/cloud/cloudservice/v1"
 
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 )
@@ -27,9 +29,10 @@ type TerraformCloudProvider struct {
 
 // TerraformCloudProviderModel describes the provider data model.
 type TerraformCloudProviderModel struct {
-	APIKey        types.String `tfsdk:"api_key"`
-	Endpoint      types.String `tfsdk:"endpoint"`
-	AllowInsecure types.Bool   `tfsdk:"allow_insecure"`
+	APIKey           types.String `tfsdk:"api_key"`
+	Endpoint         types.String `tfsdk:"endpoint"`
+	AllowInsecure    types.Bool   `tfsdk:"allow_insecure"`
+	AllowedAccountID types.String `tfsdk:"allowed_account_id"`
 }
 
 func (p *TerraformCloudProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -69,6 +72,10 @@ in version control. We recommend passing credentials to this provider via enviro
 				Description: "If set to True, it allows for an insecure connection to the Temporal Cloud API. This should never be set to 'true' in production and defaults to false.",
 				Optional:    true,
 			},
+			"allowed_account_id": schema.StringAttribute{
+				Description: "The ID of the account to operate on. Prevents accidental mutation of accounts other than that listed",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -105,6 +112,14 @@ func (p *TerraformCloudProvider) Configure(ctx context.Context, req provider.Con
 				" Either apply the source of the value first, or statically set the allow_insecure flag via environment variable or in configuration.")
 	}
 
+	if data.AllowedAccountID.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("allowed_account_id"),
+			"Unknown Terraform Cloud Allowed Account ID Value",
+			"The provider cannot create a Terraform Cloud API client as there is an unknown configuration value for `allowed_account_id`."+
+				" Either apply the source of the value first, or statically set the Allowed Account ID value via environment variable or in configuration.")
+	}
+
 	apiKey := os.Getenv("TEMPORAL_CLOUD_API_KEY")
 	if !data.APIKey.IsNull() {
 		apiKey = data.APIKey.ValueString()
@@ -123,14 +138,32 @@ func (p *TerraformCloudProvider) Configure(ctx context.Context, req provider.Con
 		allowInsecure = data.AllowInsecure.ValueBool()
 	}
 
-	client, err := client.NewConnectionWithAPIKey(endpoint, allowInsecure, apiKey)
+	allowedAccountID := os.Getenv("TEMPORAL_CLOUD_ALLOWED_ACCOUNT_ID")
+	if !data.AllowedAccountID.IsNull() {
+		allowedAccountID = data.AllowedAccountID.ValueString()
+	}
+
+	cc, err := client.NewConnectionWithAPIKey(endpoint, allowInsecure, apiKey)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to connect to Temporal Cloud API", err.Error())
 		return
 	}
 
-	resp.DataSourceData = client
-	resp.ResourceData = client
+	if allowedAccountID != "" {
+		accountResp, err := cc.CloudService().GetAccount(ctx, &cloudservice.GetAccountRequest{})
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to validate allowed account ID", fmt.Sprintf("failed to get account details: %s", err.Error()))
+			return
+		}
+		currentAccountID := accountResp.GetAccount().GetId()
+		if currentAccountID != allowedAccountID {
+			resp.Diagnostics.AddError("Failed to validate allowed account ID", fmt.Sprintf("current account ID '%s' does not match allowed account ID '%s'", currentAccountID, allowedAccountID))
+			return
+		}
+	}
+
+	resp.DataSourceData = cc
+	resp.ResourceData = cc
 }
 
 func (p *TerraformCloudProvider) Resources(ctx context.Context) []func() resource.Resource {


### PR DESCRIPTION
## What was changed
This PR adds a new optional provider configuration parameter, `allowed_account_id`, that, when set, prevents operations against accounts that do not have the same ID as that provided.

## Why?
My org has a separate Temporal Cloud account for our development environment that we manage using IaC; currently, it is incredibly easy to accidentally operate on the wrong Temporal Cloud account by having the wrong API key active in our environment and has caused cross-contamination between our dev environment and staging/production environments. The AWS Terraform provider allows you to prevent this by [providing an `allowed_account_ids` configuration parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#allowed_account_ids-1) (implementation [here](https://github.com/hashicorp/terraform-provider-aws/blob/41fcc0f3b97b7d810a9f96c648e6d4a3e2756930/internal/conns/config.go#L199-L202)), which we use for our AWS resources. This provides a similar functionality.

## Checklist

### 1. Closes n/a

### 2. How was this tested:
This unfortunately needs to be tested manually (since the post-acceptance test delete returns an (expected) error). at a later date we might want to consider generating some mocks to fully test the provider configuration.
Test steps:

1. build and install the provider as according to the Readme
2. create a simple `main.tf` with the following, replacing `ACCOUNT_ID` with the appropriate account ID:

```
provider "temporalcloud" {
   allowed_account_id = "ACCOUNT_ID"
}

data "temporalcloud_namespaces" "test" {}
``` 
3. run `terraform init && terraform apply`
4. the apply should run successfully
5. edit `main.tf` to match the following:
```
provider "temporalcloud" {
   allowed_account_id = "non-existent-account-id"
}

data "temporalcloud_namespaces" "test" {}
``` 
6. run `terraform init && terraform apply` again
7. this time, the apply should fail with an error stating that the current account ID does not match the allowed account ID

### 3. Any docs updates needed?
Docs generated!
