### PR TITLE
Add operation ids to all create, update, and delete calls

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - godot
     - gofmt

--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"time"
 
@@ -191,6 +192,7 @@ func (r *apiKeyResource) Create(ctx context.Context, req resource.CreateRequest,
 			ExpiryTime:  expiryTimestamp,
 			Disabled:    disabled,
 		},
+		AsyncOperationId: uuid.New().String(),
 	})
 
 	if err != nil {
@@ -293,7 +295,8 @@ func (r *apiKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 			ExpiryTime:  expiryTimestamp,
 			Disabled:    disabled,
 		},
-		ResourceVersion: apiKey.GetApiKey().GetResourceVersion(),
+		ResourceVersion:  apiKey.GetApiKey().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update API key", err.Error())
@@ -345,8 +348,9 @@ func (r *apiKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	defer cancel()
 
 	svcResp, err := r.client.CloudService().DeleteApiKey(ctx, &cloudservicev1.DeleteApiKeyRequest{
-		KeyId:           state.ID.ValueString(),
-		ResourceVersion: apiKey.GetApiKey().GetResourceVersion(),
+		KeyId:            state.ID.ValueString(),
+		ResourceVersion:  apiKey.GetApiKey().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete API key", err.Error())

--- a/internal/provider/metrics_endpoint_resource.go
+++ b/internal/provider/metrics_endpoint_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -138,6 +139,7 @@ func (r *metricsEndpointResource) Create(ctx context.Context, req resource.Creat
 				AcceptedClientCa: certs,
 			},
 		},
+		AsyncOperationId: uuid.New().String(),
 	}
 
 	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
@@ -219,6 +221,7 @@ func (r *metricsEndpointResource) Update(ctx context.Context, req resource.Updat
 				AcceptedClientCa: certs,
 			},
 		},
+		AsyncOperationId: uuid.New().String(),
 	}
 
 	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
@@ -270,6 +273,7 @@ func (r *metricsEndpointResource) Delete(ctx context.Context, req resource.Delet
 		Spec: &accountv1.AccountSpec{
 			Metrics: nil,
 		},
+		AsyncOperationId: uuid.New().String(),
 	}
 
 	deleteCtx, cancel := context.WithTimeout(ctx, deleteTimeout)

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/google/uuid"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -341,7 +342,8 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	svcResp, err := r.client.CloudService().CreateNamespace(ctx, &cloudservicev1.CreateNamespaceRequest{
-		Spec: spec,
+		Spec:             spec,
+		AsyncOperationId: uuid.New().String(),
 	})
 
 	if err != nil {
@@ -468,9 +470,10 @@ func (r *namespaceResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	svcResp, err := r.client.CloudService().UpdateNamespace(ctx, &cloudservicev1.UpdateNamespaceRequest{
-		Namespace:       plan.ID.ValueString(),
-		Spec:            spec,
-		ResourceVersion: currentNs.GetNamespace().GetResourceVersion(),
+		Namespace:        plan.ID.ValueString(),
+		Spec:             spec,
+		ResourceVersion:  currentNs.GetNamespace().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update namespace", err.Error())
@@ -522,8 +525,9 @@ func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
 	defer cancel()
 	svcResp, err := r.client.CloudService().DeleteNamespace(ctx, &cloudservicev1.DeleteNamespaceRequest{
-		Namespace:       state.ID.ValueString(),
-		ResourceVersion: currentNs.GetNamespace().GetResourceVersion(),
+		Namespace:        state.ID.ValueString(),
+		ResourceVersion:  currentNs.GetNamespace().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete namespace", err.Error())

--- a/internal/provider/namespace_search_attribute_resource.go
+++ b/internal/provider/namespace_search_attribute_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -137,9 +138,10 @@ func (r *namespaceSearchAttributeResource) Create(ctx context.Context, req resou
 
 		spec.GetSearchAttributes()[plan.Name.ValueString()] = saType
 		svcResp, err := r.client.CloudService().UpdateNamespace(ctx, &cloudservicev1.UpdateNamespaceRequest{
-			Namespace:       plan.NamespaceID.ValueString(),
-			Spec:            spec,
-			ResourceVersion: ns.GetNamespace().GetResourceVersion(),
+			Namespace:        plan.NamespaceID.ValueString(),
+			Spec:             spec,
+			ResourceVersion:  ns.GetNamespace().GetResourceVersion(),
+			AsyncOperationId: uuid.New().String(),
 		})
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to update namespace", err.Error())
@@ -244,9 +246,10 @@ func (r *namespaceSearchAttributeResource) Update(ctx context.Context, req resou
 		// Assumption: a search attribute named plan.Name already exists
 		spec.GetSearchAttributes()[plan.Name.ValueString()] = saType
 		svcResp, err := r.client.CloudService().UpdateNamespace(ctx, &cloudservicev1.UpdateNamespaceRequest{
-			Namespace:       plan.NamespaceID.ValueString(),
-			Spec:            spec,
-			ResourceVersion: ns.GetNamespace().GetResourceVersion(),
+			Namespace:        plan.NamespaceID.ValueString(),
+			Spec:             spec,
+			ResourceVersion:  ns.GetNamespace().GetResourceVersion(),
+			AsyncOperationId: uuid.New().String(),
 		})
 		if err != nil {
 			resp.Diagnostics.AddError("Failed to update namespace", err.Error())

--- a/internal/provider/nexus_endpoint_resource.go
+++ b/internal/provider/nexus_endpoint_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -173,6 +174,7 @@ func (r *nexusEndpointResource) Create(ctx context.Context, req resource.CreateR
 			TargetSpec:  targetSpec,
 			PolicySpecs: policySpecs,
 		},
+		AsyncOperationId: uuid.New().String(),
 	})
 
 	if err != nil {
@@ -267,7 +269,8 @@ func (r *nexusEndpointResource) Update(ctx context.Context, req resource.UpdateR
 			TargetSpec:  targetSpec,
 			PolicySpecs: policySpecs,
 		},
-		ResourceVersion: nexusEndpoint.GetEndpoint().GetResourceVersion(),
+		ResourceVersion:  nexusEndpoint.GetEndpoint().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update Nexus endpoint", err.Error())
@@ -319,8 +322,9 @@ func (r *nexusEndpointResource) Delete(ctx context.Context, req resource.DeleteR
 	defer cancel()
 
 	svcResp, err := r.client.CloudService().DeleteNexusEndpoint(ctx, &cloudservicev1.DeleteNexusEndpointRequest{
-		EndpointId:      state.ID.ValueString(),
-		ResourceVersion: nexusEndpoint.GetEndpoint().GetResourceVersion(),
+		EndpointId:       state.ID.ValueString(),
+		ResourceVersion:  nexusEndpoint.GetEndpoint().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete Nexus endpoint", err.Error())

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -188,6 +189,7 @@ func (r *serviceAccountResource) Create(ctx context.Context, req resource.Create
 				NamespaceAccesses: namespaceAccesses,
 			},
 		},
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create Service Account", err.Error())
@@ -272,7 +274,8 @@ func (r *serviceAccountResource) Update(ctx context.Context, req resource.Update
 				NamespaceAccesses: namespaceAccesses,
 			},
 		},
-		ResourceVersion: currentServiceAccount.ServiceAccount.GetResourceVersion(),
+		ResourceVersion:  currentServiceAccount.ServiceAccount.GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update Service Account", err.Error())
@@ -326,6 +329,7 @@ func (r *serviceAccountResource) Delete(ctx context.Context, req resource.Delete
 	svcResp, err := r.client.CloudService().DeleteServiceAccount(ctx, &cloudservicev1.DeleteServiceAccountRequest{
 		ServiceAccountId: state.ID.ValueString(),
 		ResourceVersion:  currentServiceAccount.ServiceAccount.GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete Service Account", err.Error())

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/validation"
 
@@ -188,6 +189,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 				NamespaceAccesses: namespaceAccesses,
 			},
 		},
+		AsyncOperationId: uuid.New().String(),
 	})
 
 	if err != nil {
@@ -275,7 +277,8 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 				NamespaceAccesses: namespaceAccesses,
 			},
 		},
-		ResourceVersion: currentUser.GetUser().GetResourceVersion(),
+		ResourceVersion:  currentUser.GetUser().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update user", err.Error())
@@ -328,8 +331,9 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	defer cancel()
 
 	svcResp, err := r.client.CloudService().DeleteUser(ctx, &cloudservicev1.DeleteUserRequest{
-		UserId:          state.ID.ValueString(),
-		ResourceVersion: currentUser.GetUser().GetResourceVersion(),
+		UserId:           state.ID.ValueString(),
+		ResourceVersion:  currentUser.GetUser().GetResourceVersion(),
+		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to delete user", err.Error())


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This adds an `AsyncOperationId` to all Create, Update, or Delete calls. This ensures that any client-side retry will be idempotent.