### PR TITLE
Handle not found errors on resource Read and Delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.7
 toolchain go1.23.2
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.2.0
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
@@ -40,7 +41,6 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0 // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -13,7 +13,9 @@ func StatusCode(err error) codes.Code {
 
 	if serviceErr, ok := err.(serviceerror.ServiceError); ok {
 		st := serviceErr.Status()
-		return st.Code()
+		if st != nil {
+			return st.Code()
+		}
 	}
 
 	return status.Code(err)

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"go.temporal.io/api/serviceerror"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func StatusCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+
+	if serviceErr, ok := err.(serviceerror.ServiceError); ok {
+		st := serviceErr.Status()
+		return st.Code()
+	}
+
+	return status.Code(err)
+}

--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -233,6 +236,16 @@ func (r *apiKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		KeyId: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "API Key Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get API key", err.Error())
 		return
 	}
@@ -340,6 +353,15 @@ func (r *apiKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		KeyId: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "API Key Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get current API key status", err.Error())
 		return
 	}
@@ -353,6 +375,15 @@ func (r *apiKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "API Key Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to delete API key", err.Error())
 		return
 	}

--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -236,7 +235,7 @@ func (r *apiKeyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		KeyId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "API Key Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -353,7 +352,7 @@ func (r *apiKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		KeyId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "API Key Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -375,7 +374,7 @@ func (r *apiKeyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "API Key Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -387,7 +386,7 @@ func (r *namespaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		Namespace: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Namespace Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -532,7 +531,7 @@ func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		Namespace: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Namespace Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -552,7 +551,7 @@ func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Namespace Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -27,6 +27,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -384,6 +387,16 @@ func (r *namespaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		Namespace: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Namespace Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get namespace", err.Error())
 		return
 	}
@@ -519,6 +532,15 @@ func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		Namespace: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Namespace Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get current namespace status", err.Error())
 		return
 	}
@@ -530,6 +552,15 @@ func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Namespace Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to delete namespace", err.Error())
 		return
 	}

--- a/internal/provider/namespace_search_attribute_resource.go
+++ b/internal/provider/namespace_search_attribute_resource.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -189,7 +188,7 @@ func (r *namespaceSearchAttributeResource) Read(ctx context.Context, req resourc
 		Namespace: state.NamespaceID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Namespace Search Attribute Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),

--- a/internal/provider/namespace_search_attribute_resource.go
+++ b/internal/provider/namespace_search_attribute_resource.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -186,6 +189,16 @@ func (r *namespaceSearchAttributeResource) Read(ctx context.Context, req resourc
 		Namespace: state.NamespaceID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Namespace Search Attribute Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get namespace", err.Error())
 		return
 	}

--- a/internal/provider/nexus_endpoint_resource.go
+++ b/internal/provider/nexus_endpoint_resource.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -213,6 +216,16 @@ func (r *nexusEndpointResource) Read(ctx context.Context, req resource.ReadReque
 		EndpointId: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Nexus Endpoint Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get Nexus endpoint", err.Error())
 		return
 	}
@@ -314,6 +327,15 @@ func (r *nexusEndpointResource) Delete(ctx context.Context, req resource.DeleteR
 		EndpointId: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Nexus Endpoint Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get current Nexus endpoint status", err.Error())
 		return
 	}
@@ -327,6 +349,15 @@ func (r *nexusEndpointResource) Delete(ctx context.Context, req resource.DeleteR
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Nexus Endpoint Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to delete Nexus endpoint", err.Error())
 		return
 	}

--- a/internal/provider/nexus_endpoint_resource.go
+++ b/internal/provider/nexus_endpoint_resource.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -216,7 +214,7 @@ func (r *nexusEndpointResource) Read(ctx context.Context, req resource.ReadReque
 		EndpointId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Nexus Endpoint Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -327,7 +325,7 @@ func (r *nexusEndpointResource) Delete(ctx context.Context, req resource.DeleteR
 		EndpointId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Nexus Endpoint Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -349,7 +347,7 @@ func (r *nexusEndpointResource) Delete(ctx context.Context, req resource.DeleteR
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Nexus Endpoint Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -226,6 +229,16 @@ func (r *serviceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		ServiceAccountId: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Service Account Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get Service Account", err.Error())
 		return
 	}
@@ -319,6 +332,15 @@ func (r *serviceAccountResource) Delete(ctx context.Context, req resource.Delete
 		ServiceAccountId: state.ID.ValueString(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Service Account Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to get current Service Account status", err.Error())
 		return
 	}
@@ -332,6 +354,15 @@ func (r *serviceAccountResource) Delete(ctx context.Context, req resource.Delete
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
+		switch status.Code(err) {
+		case codes.NotFound:
+			tflog.Warn(ctx, "Service Account Resource not found, removing from state", map[string]interface{}{
+				"id": state.ID.ValueString(),
+			})
+
+			return
+		}
+
 		resp.Diagnostics.AddError("Failed to delete Service Account", err.Error())
 		return
 	}

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -4,12 +4,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -21,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
 
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/provider/enums"
@@ -229,7 +227,7 @@ func (r *serviceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		ServiceAccountId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Service Account Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -332,7 +330,7 @@ func (r *serviceAccountResource) Delete(ctx context.Context, req resource.Delete
 		ServiceAccountId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Service Account Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -354,7 +352,7 @@ func (r *serviceAccountResource) Delete(ctx context.Context, req resource.Delete
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "Service Account Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -4,13 +4,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/temporalio/terraform-provider-temporalcloud/internal/validation"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -22,11 +17,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/provider/enums"
 	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
+	"github.com/temporalio/terraform-provider-temporalcloud/internal/validation"
 	cloudservicev1 "go.temporal.io/api/cloud/cloudservice/v1"
 	identityv1 "go.temporal.io/api/cloud/identity/v1"
+	"google.golang.org/grpc/codes"
 )
 
 type (
@@ -231,7 +229,7 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		UserId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "User Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -336,7 +334,7 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		UserId: state.ID.ValueString(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "User Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),
@@ -358,7 +356,7 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
-		switch status.Code(err) {
+		switch client.StatusCode(err) {
 		case codes.NotFound:
 			tflog.Warn(ctx, "User Resource not found, removing from state", map[string]interface{}{
 				"id": state.ID.ValueString(),


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This PR catches and ignores Not Found errors on resource Read and Delete calls. This allows drift to be detected between temporal cloud and terraform state. 

Closes #222 

## Why?
Terraform recommends this behavior for Read and Delete. 

### Read
https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations

> Ignore returning errors that signify the resource is no longer existent, call the response state `RemoveResource()` method, and return early. The next Terraform plan will recreate the resource.

### Delete
https://developer.hashicorp.com/terraform/plugin/framework/resources/delete#recommendations

>  Ignore errors that signify the resource is no longer existent.
>  Skip calling the response state RemoveResource() method. The framework automatically handles this logic with the response state if there are no error diagnostics.
