### PR TITLE
feat: allow 'none' for user account access

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -54,7 +54,7 @@ resource "temporalcloud_user" "namespace_admin" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.
+- `account_access` (String) The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support. none is only valid for users managed via SCIM that derive their roles from group memberships.
 - `email` (String) The email address for the user.
 
 ### Optional

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -54,7 +54,7 @@ resource "temporalcloud_user" "namespace_admin" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support. none is only valid for import and users created via SCIM.
+- `account_access` (String) The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.
 - `email` (String) The email address for the user.
 
 ### Optional

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -54,7 +54,7 @@ resource "temporalcloud_user" "namespace_admin" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of owner, admin, developer, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.
+- `account_access` (String) The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support. none is only valid for import and users created via SCIM.
 - `email` (String) The email address for the user.
 
 ### Optional

--- a/internal/provider/enums/identity.go
+++ b/internal/provider/enums/identity.go
@@ -48,6 +48,8 @@ func ToAccountAccessRole(s string) (identity.AccountAccess_Role, error) {
 		return identity.AccountAccess_ROLE_READ, nil
 	case "financeadmin":
 		return identity.AccountAccess_ROLE_FINANCE_ADMIN, nil
+	case "none":
+		return identity.AccountAccess_ROLE_UNSPECIFIED, nil
 	default:
 		return identity.AccountAccess_ROLE_UNSPECIFIED, fmt.Errorf("%w: %s", ErrInvalidAccountAccessRole, s)
 	}
@@ -65,6 +67,8 @@ func FromAccountAccessRole(r identity.AccountAccess_Role) (string, error) {
 		return "read", nil
 	case identity.AccountAccess_ROLE_FINANCE_ADMIN:
 		return "financeadmin", nil
+	case identity.AccountAccess_ROLE_UNSPECIFIED:
+		return "none", nil
 	default:
 		return "", fmt.Errorf("%w: %v", ErrInvalidAccountAccessRole, r)
 	}

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -114,7 +114,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 			},
 			"account_access": schema.StringAttribute{
 				CustomType:  internaltypes.CaseInsensitiveStringType{},
-				Description: "The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.",
+				Description: "The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support. none is only valid for users managed via SCIM that derive their roles from group memberships.",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOfCaseInsensitive("owner", "admin", "developer", "read", "none"),

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -23,6 +24,7 @@ import (
 	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/validation"
 	cloudservicev1 "go.temporal.io/api/cloud/cloudservice/v1"
+	"go.temporal.io/api/cloud/identity/v1"
 	identityv1 "go.temporal.io/api/cloud/identity/v1"
 	"google.golang.org/grpc/codes"
 )
@@ -112,10 +114,10 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 			},
 			"account_access": schema.StringAttribute{
 				CustomType:  internaltypes.CaseInsensitiveStringType{},
-				Description: "The role on the account. Must be one of owner, admin, developer, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.",
+				Description: "The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support.",
 				Required:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive("owner", "admin", "developer", "read"),
+					stringvalidator.OneOfCaseInsensitive("owner", "admin", "developer", "read", "none"),
 				},
 			},
 			"namespace_accesses": schema.SetNestedAttribute{
@@ -277,16 +279,22 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		resp.Diagnostics.AddError("Failed to convert account access role", err.Error())
 		return
 	}
+	access := &identityv1.Access{
+		AccountAccess: &identityv1.AccountAccess{
+			Role: role,
+		},
+		NamespaceAccesses: namespaceAccesses,
+	}
+	// If the role is unspecified (i.e. none), remove the account access from the spec.
+	if role == identity.AccountAccess_ROLE_UNSPECIFIED {
+		access.AccountAccess = nil
+	}
+
 	svcResp, err := r.client.CloudService().UpdateUser(ctx, &cloudservicev1.UpdateUserRequest{
 		UserId: plan.ID.ValueString(),
 		Spec: &identityv1.UserSpec{
-			Email: plan.Email.ValueString(),
-			Access: &identityv1.Access{
-				AccountAccess: &identityv1.AccountAccess{
-					Role: role,
-				},
-				NamespaceAccesses: namespaceAccesses,
-			},
+			Email:  plan.Email.ValueString(),
+			Access: access,
 		},
 		ResourceVersion:  currentUser.GetUser().GetResourceVersion(),
 		AsyncOperationId: uuid.New().String(),

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -79,9 +79,6 @@ resource "temporalcloud_user" "terraform" {
 				Config: config(emailAddr, "admin"),
 			},
 			{
-				Config: config(emailAddr, "none"),
-			},
-			{
 				ImportState:       true,
 				ImportStateVerify: true,
 				ResourceName:      "temporalcloud_user.terraform",

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -79,6 +79,9 @@ resource "temporalcloud_user" "terraform" {
 				Config: config(emailAddr, "admin"),
 			},
 			{
+				Config: config(emailAddr, "none"),
+			},
+			{
 				ImportState:       true,
 				ImportStateVerify: true,
 				ResourceName:      "temporalcloud_user.terraform",
@@ -133,7 +136,7 @@ resource "temporalcloud_user" "terraform" {
       permission = "{{ .NamespacePerm }}"
     }
   ]
-  
+
   depends_on = [temporalcloud_namespace.test]
 }`))
 
@@ -215,7 +218,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_user" "terraform" {
   email = "{{ .Email }}"
-  account_access = "read" 
+  account_access = "read"
   namespace_accesses = []
 }`))
 
@@ -261,7 +264,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_user" "terraform" {
   email = "{{ .Email }}"
-  account_access = "read" 
+  account_access = "read"
   namespace_accesses = [
     {
        namespace_id = "NS1"
@@ -334,7 +337,7 @@ resource "temporalcloud_namespace" "test2" {
 
 resource "temporalcloud_user" "terraform" {
   email = "{{ .Email }}"
-  account_access = "read" 
+  account_access = "read"
   namespace_accesses = [
     {
       namespace_id = temporalcloud_namespace.test.id


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This allows user roles to be `none` in certain circumstances

## Why?
<!-- Tell your future self why have you made these changes -->
Users created via SCIM are allowed to have no specified account access because they derive their roles from group membership. This update allows those users to be imported and then their access managed via terraform. 

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manual testing because it requires a SCIM configured user
2. Any docs updates needed?
Done
