### PR TITLE
Namespace data sources VPC endpoint service names

### DIFF
--- a/internal/provider/namespaces_datasource.go
+++ b/internal/provider/namespaces_datasource.go
@@ -439,7 +439,7 @@ func namespaceToNamespaceDataModel(ctx context.Context, ns *namespacev1.Namespac
 			}
 			awsPrivLinkModel.AllowedPrincipalArns = principals
 
-			serviceNames, listDiags := types.ListValueFrom(ctx, types.StringType, privateConn.GetAwsPrivateLink().GetAllowedPrincipalArns())
+			serviceNames, listDiags := types.ListValueFrom(ctx, types.StringType, privateConn.GetAwsPrivateLink().GetVpcEndpointServiceNames())
 			diags.Append(listDiags...)
 			if diags.HasError() {
 				return nil, diags


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Namespace data sources return VPC endpoint service names instead of allowed principle ARNs.

## Why?
Bug, currently looks like this.
```
              + private_connectivities   = [
                  + {
                      + aws_private_link_info = {
                          + allowed_principal_arns     = [
                              + "arn:aws:iam::redacted:root",
                            ]
                          + vpc_endpoint_service_names = [
                              + "arn:aws:iam::redacted:root",
                            ]
                        }
                      + region                = "aws-redacted"
                    },
                ]

```

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Return type the same, https://pkg.go.dev/go.temporal.io/cloud-sdk@v0.2.0/api/namespace/v1#AWSPrivateLinkInfo.GetVpcEndpointServiceNames.
