### PR TITLE
Allow for API Key and mTLS Auth

### DIFF
--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -138,7 +138,7 @@ resource "temporalcloud_namespace" "terraform3" {
 ### Optional
 
 - `accepted_client_ca` (String) The Base64-encoded CA cert in PEM format that clients use when authenticating with Temporal Cloud. This is a required field when a Namespace uses mTLS authentication.
-- `api_key_auth` (Boolean) If true, Temporal Cloud will use API key authentication for this namespace.
+- `api_key_auth` (Boolean) If true, Temporal Cloud will enable API key authentication for this namespace.
 - `certificate_filters` (Attributes List) A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. Empty lists are not allowed, omit the attribute instead. (see [below for nested schema](#nestedatt--certificate_filters))
 - `codec_server` (Attributes) A codec server is used by the Temporal Cloud UI to decode payloads for all users interacting with this namespace, even if the workflow history itself is encrypted. (see [below for nested schema](#nestedatt--codec_server))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -138,7 +138,7 @@ resource "temporalcloud_namespace" "terraform3" {
 ### Optional
 
 - `accepted_client_ca` (String) The Base64-encoded CA cert in PEM format that clients use when authenticating with Temporal Cloud. This is a required field when a Namespace uses mTLS authentication.
-- `api_key_auth` (Boolean) If true, Temporal Cloud will use API key authentication for this namespace. If false, mutual TLS (mTLS) authentication will be used.
+- `api_key_auth` (Boolean) If true, Temporal Cloud will use API key authentication for this namespace.
 - `certificate_filters` (Attributes List) A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. Empty lists are not allowed, omit the attribute instead. (see [below for nested schema](#nestedatt--certificate_filters))
 - `codec_server` (Attributes) A codec server is used by the Temporal Cloud UI to decode payloads for all users interacting with this namespace, even if the workflow history itself is encrypted. (see [below for nested schema](#nestedatt--codec_server))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -220,7 +220,7 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				},
 			},
 			"api_key_auth": schema.BoolAttribute{
-				Description: "If true, Temporal Cloud will use API key authentication for this namespace.",
+				Description: "If true, Temporal Cloud will enable API key authentication for this namespace.",
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -318,18 +318,16 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 		CodecServer:   codecServer,
 	}
 
-	if plan.ApiKeyAuth.ValueBool() {
-		if !plan.AcceptedClientCA.IsNull() {
-			resp.Diagnostics.AddError("accepted_client_ca is not allowed when API key authentication is enabled (api_key_auth is set to true).", "")
-			return
-		}
-		spec.ApiKeyAuth = &namespacev1.ApiKeyAuthSpec{Enabled: true}
+	if !plan.ApiKeyAuth.ValueBool() && plan.AcceptedClientCA.IsNull() {
+		resp.Diagnostics.AddError("Namespace not configured with authentication", "accepted_client_ca or api_key_auth must be set")
+		return
+	}
 
-	} else {
-		if plan.AcceptedClientCA.IsNull() {
-			resp.Diagnostics.AddError("Namespace not configured with authentication. accepted_client_ca is required when API key authentication is not enabled (api_key_auth is not set to true).", "")
-			return
-		}
+	if plan.ApiKeyAuth.ValueBool() {
+		spec.ApiKeyAuth = &namespacev1.ApiKeyAuthSpec{Enabled: true}
+	}
+
+	if !plan.AcceptedClientCA.IsNull() {
 		mtls := &namespacev1.MtlsAuthSpec{}
 		if plan.AcceptedClientCA.ValueString() != "" {
 			certs, err := base64.StdEncoding.DecodeString(plan.AcceptedClientCA.ValueString())
@@ -455,18 +453,16 @@ func (r *namespaceResource) Update(ctx context.Context, req resource.UpdateReque
 		SearchAttributes: currentNs.GetNamespace().GetSpec().GetSearchAttributes(),
 	}
 
-	if plan.ApiKeyAuth.ValueBool() {
-		if !plan.AcceptedClientCA.IsNull() {
-			resp.Diagnostics.AddError("accepted_client_ca is not allowed when API key authentication is enabled (api_key_auth is set to true).", "")
-			return
-		}
-		spec.ApiKeyAuth = &namespacev1.ApiKeyAuthSpec{Enabled: true}
-	} else {
-		if plan.AcceptedClientCA.IsNull() {
-			resp.Diagnostics.AddError("Namespace not configured with authentication. accepted_client_ca is required when API key authentication is not enabled (api_key_auth is not set to true).", "")
-			return
-		}
+	if !plan.ApiKeyAuth.ValueBool() && plan.AcceptedClientCA.IsNull() {
+		resp.Diagnostics.AddError("Namespace not configured with authentication", "accepted_client_ca or api_key_auth must be set")
+		return
+	}
 
+	if plan.ApiKeyAuth.ValueBool() {
+		spec.ApiKeyAuth = &namespacev1.ApiKeyAuthSpec{Enabled: true}
+	}
+
+	if !plan.AcceptedClientCA.IsNull() {
 		mtls := &namespacev1.MtlsAuthSpec{}
 
 		if plan.AcceptedClientCA.ValueString() != "" {

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -220,7 +220,7 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				},
 			},
 			"api_key_auth": schema.BoolAttribute{
-				Description: "If true, Temporal Cloud will use API key authentication for this namespace. If false, mutual TLS (mTLS) authentication will be used.",
+				Description: "If true, Temporal Cloud will use API key authentication for this namespace.",
 				Optional:    true,
 				Computed:    true,
 			},

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -205,6 +205,7 @@ func TestAccNamespaceWithCodecServer(t *testing.T) {
 			RetentionDays        int
 			CodecServer          *codecServer
 			ApiKeyAuth           bool
+			TLSAuth              bool
 			CertFiltersEmptyList bool
 		}
 	)
@@ -223,7 +224,7 @@ resource "temporalcloud_namespace" "test" {
 	  api_key_auth = true
 	  {{ end }}
 
-	{{ if not .ApiKeyAuth }}
+	{{ if .TLSAuth }}
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIBxjCCAU2gAwIBAgIRAlyZ5KUmunPLeFAupDwGL8AwCgYIKoZIzj0EAwMwEjEQ
@@ -277,12 +278,14 @@ PEM
 					Name:          name,
 					RetentionDays: 7,
 				}),
+				ExpectError: regexp.MustCompile("Namespace not configured with authentication")
 			},
 			{
 				// Error on empty cert filers
 				Config: config(configArgs{
 					Name:                 name,
 					RetentionDays:        7,
+					TLSAuth: true,
 					CertFiltersEmptyList: true,
 				}),
 				ExpectError: regexp.MustCompile("certificate_filters list must contain at least 1 elements"),
@@ -291,6 +294,7 @@ PEM
 				Config: config(configArgs{
 					Name:          name,
 					RetentionDays: 7,
+					TLSAuth: true,
 					CodecServer: &codecServer{
 						Endpoint:                      "https://example.com",
 						PassAccessToken:               true,
@@ -330,6 +334,7 @@ PEM
 				Config: config(configArgs{
 					Name:          name,
 					RetentionDays: 7,
+					TLSAuth: true,
 				}),
 				Check: func(s *terraform.State) error {
 					id := s.RootModule().Resources["temporalcloud_namespace.test"].Primary.Attributes["id"]
@@ -389,6 +394,31 @@ PEM
 					Name:          name,
 					RetentionDays: 7,
 					ApiKeyAuth:    true,
+				}),
+				Check: func(s *terraform.State) error {
+					id := s.RootModule().Resources["temporalcloud_namespace.test"].Primary.Attributes["id"]
+					conn := newConnection(t)
+					ns, err := conn.GetNamespace(context.Background(), &cloudservicev1.GetNamespaceRequest{
+						Namespace: id,
+					})
+					if err != nil {
+						return fmt.Errorf("failed to get namespace: %v", err)
+					}
+
+					spec := ns.Namespace.GetSpec()
+					if spec.GetCodecServer().GetEndpoint() != "" {
+						return fmt.Errorf("unexpected endpoint: %s", spec.GetCodecServer().GetEndpoint())
+					}
+					return nil
+				},
+			},
+			{
+				// both auth methods
+				Config: config(configArgs{
+					Name:          name,
+					RetentionDays: 7,
+					ApiKeyAuth:    true,
+					TLSAuth:       true,
 				}),
 				Check: func(s *terraform.State) error {
 					id := s.RootModule().Resources["temporalcloud_namespace.test"].Primary.Attributes["id"]

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -278,14 +278,14 @@ PEM
 					Name:          name,
 					RetentionDays: 7,
 				}),
-				ExpectError: regexp.MustCompile("Namespace not configured with authentication")
+				ExpectError: regexp.MustCompile("Namespace not configured with authentication"),
 			},
 			{
 				// Error on empty cert filers
 				Config: config(configArgs{
 					Name:                 name,
 					RetentionDays:        7,
-					TLSAuth: true,
+					TLSAuth:              true,
 					CertFiltersEmptyList: true,
 				}),
 				ExpectError: regexp.MustCompile("certificate_filters list must contain at least 1 elements"),
@@ -294,7 +294,7 @@ PEM
 				Config: config(configArgs{
 					Name:          name,
 					RetentionDays: 7,
-					TLSAuth: true,
+					TLSAuth:       true,
 					CodecServer: &codecServer{
 						Endpoint:                      "https://example.com",
 						PassAccessToken:               true,
@@ -334,7 +334,7 @@ PEM
 				Config: config(configArgs{
 					Name:          name,
 					RetentionDays: 7,
-					TLSAuth: true,
+					TLSAuth:       true,
 				}),
 				Check: func(s *terraform.State) error {
 					id := s.RootModule().Resources["temporalcloud_namespace.test"].Primary.Attributes["id"]


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Allows for Namespace Resources to be configured with both API Key and mTLS Authentication to match the API semantics.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

Closes #283 

How was this tested:
Acceptance tests

Any docs updates needed?
No
