### PR TITLE
fix: error when access set incorrectly on groups

### DIFF
--- a/internal/provider/access.go
+++ b/internal/provider/access.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -60,6 +61,10 @@ func addAccessSchemaAttrs(s schema.Schema) {
 		Validators: []validator.Set{
 			setvalidator.SizeAtLeast(1),
 			validation.SetNestedAttributeMustBeUnique("namespace_id"),
+			validation.SetMustBeEmptyWhen(
+				path.Root("account_access"),
+				[]string{"owner", "admin"},
+			),
 		},
 	}
 }

--- a/internal/validation/set_empty_when.go
+++ b/internal/validation/set_empty_when.go
@@ -1,0 +1,65 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/temporalio/terraform-provider-temporalcloud/internal/types"
+)
+
+type setEmptyWhen struct {
+	otherPath path.Path
+	values    []string
+}
+
+// SetMustBeEmptyWhen returns a validator that ensures a set is empty when another attribute has any of the specified values
+func SetMustBeEmptyWhen(otherPath path.Path, values []string) validator.Set {
+	return setEmptyWhen{
+		otherPath: otherPath,
+		values:    values,
+	}
+}
+
+func (s setEmptyWhen) Description(_ context.Context) string {
+	return fmt.Sprintf("Validates that the set is empty when the attribute at %s has any of the values: %s", s.otherPath, strings.Join(s.values, ", "))
+}
+
+func (s setEmptyWhen) MarkdownDescription(ctx context.Context) string {
+	return s.Description(ctx)
+}
+
+func (s setEmptyWhen) ValidateSet(ctx context.Context, req validator.SetRequest, resp *validator.SetResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Get the value of the other attribute
+	var otherValue types.CaseInsensitiveStringValue
+	diags := req.Config.GetAttribute(ctx, s.otherPath, &otherValue)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if otherValue.IsNull() || otherValue.IsUnknown() {
+		return
+	}
+
+	otherValueStr := strings.ToLower(otherValue.ValueString())
+	for _, value := range s.values {
+		if strings.ToLower(value) == otherValueStr {
+			// If the other value matches and the set is not empty, return an error
+			if len(req.ConfigValue.Elements()) > 0 {
+				resp.Diagnostics.AddAttributeError(
+					req.Path,
+					"Invalid Set Value",
+					fmt.Sprintf("%s must be empty when %s is %s", req.Path, s.otherPath, otherValueStr),
+				)
+			}
+			return
+		}
+	}
+}

--- a/internal/validation/set_empty_when.go
+++ b/internal/validation/set_empty_when.go
@@ -15,7 +15,7 @@ type setEmptyWhen struct {
 	values    []string
 }
 
-// SetMustBeEmptyWhen returns a validator that ensures a set is empty when another attribute has any of the specified values
+// SetMustBeEmptyWhen returns a validator that ensures a set is empty when another attribute has any of the specified values.
 func SetMustBeEmptyWhen(otherPath path.Path, values []string) validator.Set {
 	return setEmptyWhen{
 		otherPath: otherPath,

--- a/internal/validation/set_empty_when.go
+++ b/internal/validation/set_empty_when.go
@@ -38,6 +38,7 @@ func (s setEmptyWhen) ValidateSet(ctx context.Context, req validator.SetRequest,
 
 	// Get the value of the other attribute
 	var otherValue types.CaseInsensitiveStringValue
+
 	diags := req.Config.GetAttribute(ctx, s.otherPath, &otherValue)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/validation/set_empty_when_test.go
+++ b/internal/validation/set_empty_when_test.go
@@ -1,0 +1,170 @@
+package validation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
+)
+
+func TestSetMustBeEmptyWhen(t *testing.T) {
+	tests := []struct {
+		name           string
+		otherPath      path.Path
+		values         []string
+		setValue       types.Set
+		otherValue     internaltypes.CaseInsensitiveStringValue
+		expectedErrors bool
+	}{
+		{
+			name:           "empty set when other value matches",
+			otherPath:      path.Root("other"),
+			values:         []string{"test"},
+			setValue:       types.SetValueMust(types.StringType, []attr.Value{}),
+			otherValue:     internaltypes.CaseInsensitiveString("test"),
+			expectedErrors: false,
+		},
+		{
+			name:      "non-empty set when other value matches",
+			otherPath: path.Root("other"),
+			values:    []string{"test"},
+			setValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("value1"),
+			}),
+			otherValue:     internaltypes.CaseInsensitiveString("test"),
+			expectedErrors: true,
+		},
+		{
+			name:      "non-empty set when other value doesn't match",
+			otherPath: path.Root("other"),
+			values:    []string{"test"},
+			setValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("value1"),
+			}),
+			otherValue:     internaltypes.CaseInsensitiveString("other"),
+			expectedErrors: false,
+		},
+		{
+			name:      "case insensitive matching",
+			otherPath: path.Root("other"),
+			values:    []string{"TEST"},
+			setValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("value1"),
+			}),
+			otherValue:     internaltypes.CaseInsensitiveString("test"),
+			expectedErrors: true,
+		},
+		{
+			name:           "null set value",
+			otherPath:      path.Root("other"),
+			values:         []string{"test"},
+			setValue:       types.SetNull(types.StringType),
+			otherValue:     internaltypes.CaseInsensitiveString("test"),
+			expectedErrors: false,
+		},
+		{
+			name:           "unknown set value",
+			otherPath:      path.Root("other"),
+			values:         []string{"test"},
+			setValue:       types.SetUnknown(types.StringType),
+			otherValue:     internaltypes.CaseInsensitiveString("test"),
+			expectedErrors: false,
+		},
+		{
+			name:      "null other value",
+			otherPath: path.Root("other"),
+			values:    []string{"test"},
+			setValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("value1"),
+			}),
+			otherValue: internaltypes.CaseInsensitiveStringValue{
+				StringValue: types.StringNull(),
+			},
+			expectedErrors: false,
+		},
+		{
+			name:      "unknown other value",
+			otherPath: path.Root("other"),
+			values:    []string{"test"},
+			setValue: types.SetValueMust(types.StringType, []attr.Value{
+				types.StringValue("value1"),
+			}),
+			otherValue: internaltypes.CaseInsensitiveStringValue{
+				StringValue: types.StringUnknown(),
+			},
+			expectedErrors: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a schema with the validator
+			s := schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"test": schema.SetAttribute{
+						ElementType: types.StringType,
+						Required:    true,
+						Validators: []validator.Set{
+							SetMustBeEmptyWhen(tt.otherPath, tt.values),
+						},
+					},
+					"other": schema.StringAttribute{
+						Required:   true,
+						CustomType: internaltypes.CaseInsensitiveStringType{},
+					},
+				},
+			}
+
+			// Create the config values
+			configVal := map[string]attr.Value{
+				"test":  tt.setValue,
+				"other": tt.otherValue,
+			}
+
+			// Create the config object
+			configObj, diags := types.ObjectValue(map[string]attr.Type{
+				"test":  types.SetType{ElemType: types.StringType},
+				"other": internaltypes.CaseInsensitiveStringType{},
+			}, configVal)
+			if diags.HasError() {
+				t.Fatalf("Failed to create config object: %v", diags)
+			}
+
+			// Convert to Terraform value
+			tfValue, err := configObj.ToTerraformValue(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to convert to Terraform value: %v", err)
+			}
+
+			// Create the config
+			config := tfsdk.Config{
+				Raw:    tfValue,
+				Schema: s,
+			}
+
+			// Create a validator request
+			req := validator.SetRequest{
+				Path:        path.Root("test"),
+				ConfigValue: tt.setValue,
+				Config:      config,
+			}
+			resp := &validator.SetResponse{}
+
+			// Run the validator
+			SetMustBeEmptyWhen(tt.otherPath, tt.values).ValidateSet(context.Background(), req, resp)
+
+			if tt.expectedErrors && !resp.Diagnostics.HasError() {
+				t.Error("expected validation error but got none")
+			}
+			if !tt.expectedErrors && resp.Diagnostics.HasError() {
+				t.Errorf("unexpected validation error: %v", resp.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Because owner or admin access grants admin permission to all namespaces, the namespace accesses aren't allowed. This verifies that in the schema validation.

## Why?
<!-- Tell your future self why have you made these changes -->
So user's get a resonable error.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually on local terraform.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
