### PR TITLE
allow removal of connectivity rules to null and to empty

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -311,9 +311,6 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				CustomType: internaltypes.UnorderedStringListType{
 					ListType: basetypes.ListType{ElemType: basetypes.StringType{}},
 				},
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
-				},
 			},
 			"capacity": schema.SingleNestedAttribute{
 				Optional:    true,
@@ -862,13 +859,28 @@ func updateModelFromSpec(
 	}
 
 	// Handle connectivity rule IDs - preserve the intent from the plan
-
-	connectivityRuleIdsState := internaltypes.UnorderedStringListValue{
-		ListValue: types.ListNull(types.StringType),
-	}
 	connectivityRuleIds := ns.GetSpec().GetConnectivityRuleIds()
-	if len(connectivityRuleIds) > 0 {
-		// Use API response values
+	var connectivityRuleIdsState internaltypes.UnorderedStringListValue
+
+	if len(connectivityRuleIds) == 0 {
+		// API returns empty, preserve what was in the plan
+		if state.ConnectivityRuleIds.IsNull() {
+			// Plan had null (not set), keep null
+			connectivityRuleIdsState = internaltypes.UnorderedStringListValue{
+				ListValue: types.ListNull(types.StringType),
+			}
+		} else {
+			// Plan had empty list (explicitly set to []), keep empty list
+			emptyList, listDiags := types.ListValue(types.StringType, []attr.Value{})
+			diags.Append(listDiags...)
+			if diags.HasError() {
+				return diags
+			}
+			connectivityRuleIdsState = internaltypes.UnorderedStringListValue{
+				ListValue: emptyList,
+			}
+		}
+	} else {
 		planConnectivityRuleIds, listDiags := types.ListValueFrom(ctx, types.StringType, connectivityRuleIds)
 		diags.Append(listDiags...)
 		if diags.HasError() {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- allow removal of connectivity rules
- supports removal to empty list or to nil
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
local testing with api key
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows explicit removal of namespace connectivity rules and correct state handling.
> 
> - Removes `SizeAtLeast(1)` validator from `connectivity_rule_ids` to permit empty lists
> - Updates `updateModelFromSpec` to preserve plan intent when API returns no `connectivity_rule_ids` (keep `null` vs. empty list), otherwise reflects API values
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef28ba843c18c8d542d3cdcd1251f285ff2081df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->