### PR TITLE
Use set for connectivity rule list instead of list

### DIFF
--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -46,7 +46,7 @@ output "namespace" {
 - `api_key_auth` (Boolean) If true, Temporal Cloud will use API key authentication for this namespace. If false, mutual TLS (mTLS) authentication will be used.
 - `certificate_filters` (Attributes List) A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. (see [below for nested schema](#nestedatt--certificate_filters))
 - `codec_server` (Attributes) A codec server is used by the Temporal Cloud UI to decode payloads for all users interacting with this namespace, even if the workflow history itself is encrypted. (see [below for nested schema](#nestedatt--codec_server))
-- `connectivity_rule_ids` (List of String) The IDs of the connectivity rules for this namespace.
+- `connectivity_rule_ids` (Set of String) The IDs of the connectivity rules for this namespace.
 - `custom_search_attributes` (Map of String) The custom search attributes to use for the namespace.
 - `last_modified_time` (String) The date and time when the namespace was last modified. Will not be set if the namespace has never been modified.
 - `private_connectivities` (Attributes List) The private connectivities for the namespace, if any. (see [below for nested schema](#nestedatt--private_connectivities))

--- a/docs/data-sources/namespaces.md
+++ b/docs/data-sources/namespaces.md
@@ -48,7 +48,7 @@ Optional:
 - `api_key_auth` (Boolean) If true, Temporal Cloud will use API key authentication for this namespace. If false, mutual TLS (mTLS) authentication will be used.
 - `certificate_filters` (Attributes List) A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. (see [below for nested schema](#nestedatt--namespaces--certificate_filters))
 - `codec_server` (Attributes) A codec server is used by the Temporal Cloud UI to decode payloads for all users interacting with this namespace, even if the workflow history itself is encrypted. (see [below for nested schema](#nestedatt--namespaces--codec_server))
-- `connectivity_rule_ids` (List of String) The IDs of the connectivity rules for this namespace.
+- `connectivity_rule_ids` (Set of String) The IDs of the connectivity rules for this namespace.
 - `custom_search_attributes` (Map of String) The custom search attributes to use for the namespace.
 - `last_modified_time` (String) The date and time when the namespace was last modified. Will not be set if the namespace has never been modified.
 - `private_connectivities` (Attributes List) The private connectivities for the namespace, if any. (see [below for nested schema](#nestedatt--namespaces--private_connectivities))

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -158,7 +158,7 @@ resource "temporalcloud_namespace" "terraform4" {
 - `capacity` (Attributes) The capacity configuration for the namespace. (see [below for nested schema](#nestedatt--capacity))
 - `certificate_filters` (Attributes List) A list of filters to apply to client certificates when initiating a connection Temporal Cloud. If present, connections will only be allowed from client certificates whose distinguished name properties match at least one of the filters. Empty lists are not allowed, omit the attribute instead. (see [below for nested schema](#nestedatt--certificate_filters))
 - `codec_server` (Attributes) A codec server is used by the Temporal Cloud UI to decode payloads for all users interacting with this namespace, even if the workflow history itself is encrypted. (see [below for nested schema](#nestedatt--codec_server))
-- `connectivity_rule_ids` (List of String) The IDs of the connectivity rules for this namespace.
+- `connectivity_rule_ids` (Set of String) The IDs of the connectivity rules for this namespace.
 - `namespace_lifecycle` (Attributes) The lifecycle configuration for the namespace. Note that this is different from the Terraform resource lifecycle. This controls settings like delete protection within Temporal Cloud. (see [below for nested schema](#nestedatt--namespace_lifecycle))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -642,7 +642,7 @@ func TestAccNamespaceWithConnectivityRuleIds(t *testing.T) {
 			for _, ruleName := range includeRules {
 				ruleRefs = append(ruleRefs, fmt.Sprintf("temporalcloud_connectivity_rule.%s.id", ruleName))
 			}
-			connectivityRulesConfig = fmt.Sprintf("connectivity_rule_ids = {%s}", strings.Join(ruleRefs, ", "))
+			connectivityRulesConfig = fmt.Sprintf("connectivity_rule_ids = [%s]", strings.Join(ruleRefs, ", "))
 		}
 
 		config := fmt.Sprintf(`

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -642,7 +642,7 @@ func TestAccNamespaceWithConnectivityRuleIds(t *testing.T) {
 			for _, ruleName := range includeRules {
 				ruleRefs = append(ruleRefs, fmt.Sprintf("temporalcloud_connectivity_rule.%s.id", ruleName))
 			}
-			connectivityRulesConfig = fmt.Sprintf("connectivity_rule_ids = [%s]", strings.Join(ruleRefs, ", "))
+			connectivityRulesConfig = fmt.Sprintf("connectivity_rule_ids = {%s}", strings.Join(ruleRefs, ", "))
 		}
 
 		config := fmt.Sprintf(`

--- a/internal/provider/namespaces_datasource.go
+++ b/internal/provider/namespaces_datasource.go
@@ -56,7 +56,7 @@ type (
 		Limits                 types.Object                  `tfsdk:"limits"`
 		CreatedTime            types.String                  `tfsdk:"created_time"`
 		LastModifiedTime       types.String                  `tfsdk:"last_modified_time"`
-		ConnectivityRuleIds    types.List                    `tfsdk:"connectivity_rule_ids"`
+		ConnectivityRuleIds    types.Set                     `tfsdk:"connectivity_rule_ids"`
 		NamespaceLifecycle     internaltypes.ZeroObjectValue `tfsdk:"namespace_lifecycle"`
 		Tags                   types.Map                     `tfsdk:"tags"`
 	}
@@ -280,7 +280,7 @@ func namespaceDataSourceSchema(idRequired bool) map[string]schema.Attribute {
 			Optional:    true,
 			Description: "The date and time when the namespace was last modified. Will not be set if the namespace has never been modified.",
 		},
-		"connectivity_rule_ids": schema.ListAttribute{
+		"connectivity_rule_ids": schema.SetAttribute{
 			Computed:    true,
 			Optional:    true,
 			Description: "The IDs of the connectivity rules for this namespace.",
@@ -535,18 +535,18 @@ func namespaceToNamespaceDataModel(ctx context.Context, ns *namespacev1.Namespac
 	namespaceModel.Limits = limits
 
 	// Initialize ConnectivityRuleIds with proper type
-	connectivityRuleIds := types.ListNull(types.StringType)
+	connectivityRuleIds := types.SetNull(types.StringType)
 	if len(ns.GetSpec().GetConnectivityRuleIds()) > 0 {
 		var connectivityRuleIdStrs []attr.Value
 		for _, id := range ns.GetSpec().GetConnectivityRuleIds() {
 			connectivityRuleIdStrs = append(connectivityRuleIdStrs, types.StringValue(id))
 		}
-		connectivityRuleIdsList, listDiags := types.ListValue(types.StringType, connectivityRuleIdStrs)
-		diags.Append(listDiags...)
+		connectivityRuleIdsSet, setDiags := types.SetValue(types.StringType, connectivityRuleIdStrs)
+		diags.Append(setDiags...)
 		if diags.HasError() {
 			return nil, diags
 		}
-		connectivityRuleIds = connectivityRuleIdsList
+		connectivityRuleIds = connectivityRuleIdsSet
 	}
 	namespaceModel.ConnectivityRuleIds = connectivityRuleIds
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- this makes it so reordering the list won't make any changes
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `connectivity_rule_ids` order-insensitive.
> 
> - Change schema and models from `List` to `Set` for `connectivity_rule_ids` in `namespace` resource and `namespaces` data source; add `setvalidator.SizeAtLeast(1)`
> - Update state mapping and conversions to use `types.Set`/`SetValueFrom` instead of list helpers
> - Regenerate docs to reflect `Set of String` for `connectivity_rule_ids`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c65134d2fccdb4abc78cc2cfe449fd2b16885d3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->