### PR TITLE
Add namespace name validation

### DIFF
--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -147,7 +147,7 @@ resource "temporalcloud_namespace" "terraform4" {
 
 ### Required
 
-- `name` (String) The name of the namespace.
+- `name` (String) The name of the namespace. Must be 2-64 characters, start with a letter, contain only lowercase letters, numbers, and hyphens, and not end with a hyphen.
 - `regions` (List of String) The list of regions where this namespace is available. Must be one or two regions. See https://docs.temporal.io/cloud/regions for a list of available regions and HA options. Note that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1). If two regions are specified, the namespace will be replicated across them in a high availability (HA) configuration. Same-region, multi-region, and multi-cloud HA namespaces are supported. Please note that changing, adding, or removing regions for an existing namespace is not currently supported and the provider will throw an error. For HA namespaces the provider will ignore order changes on regions, which can happen if the namespace fails over.
 - `retention_days` (Number) The number of days to retain workflow history. Any changes to the retention period will be applied to all new running workflows.
 

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"regexp"
 	"slices"
 	"sort"
 	"time"
@@ -183,10 +184,17 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 		Description: "Provisions a Temporal Cloud namespace. \n\nRegions available in Temporal Cloud: https://docs.temporal.io/cloud/regions. \n\nNote that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1)",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				Description: "The name of the namespace.",
+				Description: "The name of the namespace. Must be 2-64 characters, start with a letter, contain only lowercase letters, numbers, and hyphens, and not end with a hyphen.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(2, 64),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`),
+						"must start with a lowercase letter, contain only lowercase letters, numbers, and hyphens, and end with a letter or number",
+					),
 				},
 			},
 			"id": schema.StringAttribute{

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -86,7 +86,7 @@ resource "temporalcloud_namespace" "test" {
 			{
 				// Name ends with hyphen
 				Config:      config("invalid-"),
-				ExpectError: regexp.MustCompile(`must start with a lowercase letter.*end with a letter or number`),
+				ExpectError: regexp.MustCompile(`(?s)must start with a lowercase letter.*end with a letter or number`),
 			},
 			{
 				// Name contains uppercase

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -45,6 +45,63 @@ func TestNamespaceSchema(t *testing.T) {
 	}
 }
 
+func TestAccNamespaceNameValidation(t *testing.T) {
+	config := func(name string) string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+}
+
+resource "temporalcloud_namespace" "test" {
+  name               = "%s"
+  regions            = ["aws-us-east-1"]
+  api_key_auth       = true
+  retention_days     = 7
+}`, name)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Name too short (1 char)
+				Config:      config("a"),
+				ExpectError: regexp.MustCompile(`string length must be between 2 and 64`),
+			},
+			{
+				// Name too long (65 chars)
+				Config:      config("a" + strings.Repeat("b", 64)),
+				ExpectError: regexp.MustCompile(`string length must be between 2 and 64`),
+			},
+			{
+				// Name starts with number
+				Config:      config("1invalid"),
+				ExpectError: regexp.MustCompile(`must start with a lowercase letter`),
+			},
+			{
+				// Name starts with hyphen
+				Config:      config("-invalid"),
+				ExpectError: regexp.MustCompile(`must start with a lowercase letter`),
+			},
+			{
+				// Name ends with hyphen
+				Config:      config("invalid-"),
+				ExpectError: regexp.MustCompile(`must start with a lowercase letter.*end with a letter or number`),
+			},
+			{
+				// Name contains uppercase
+				Config:      config("Invalid"),
+				ExpectError: regexp.MustCompile(`must start with a lowercase letter`),
+			},
+			{
+				// Name contains underscore
+				Config:      config("invalid_name"),
+				ExpectError: regexp.MustCompile(`must start with a lowercase letter`),
+			},
+		},
+	})
+}
+
 func TestAccBasicNamespace(t *testing.T) {
 	name := fmt.Sprintf("%s-%s", "tf-basic-namespace", randomString(10))
 	config := func(name string, retention int, deleteProtection bool) string {


### PR DESCRIPTION
Validates namespace name during plan:
- Length between 2-64 characters
- Must match pattern: lowercase letters, numbers, hyphens, not starting/ending with hyphen

Fixes #190