### PR TITLE
Add region validation

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -121,6 +121,7 @@ var (
 	_ resource.Resource                = (*namespaceResource)(nil)
 	_ resource.ResourceWithConfigure   = (*namespaceResource)(nil)
 	_ resource.ResourceWithImportState = (*namespaceResource)(nil)
+	_ resource.ResourceWithModifyPlan  = (*namespaceResource)(nil)
 
 	namespaceCertificateFilterAttrs = map[string]attr.Type{
 		"common_name":              types.StringType,
@@ -205,7 +206,7 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 					ListType: basetypes.ListType{ElemType: basetypes.StringType{}},
 				},
 				Validators: []validator.List{
-					listvalidator.ValueStringsAre(validators.Region()),
+					listvalidator.ValueStringsAre(validators.RegionFormat()),
 				},
 			},
 			"accepted_client_ca": schema.StringAttribute{
@@ -343,6 +344,63 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Delete: true,
 			}),
 		},
+	}
+}
+
+// ModifyPlan validates configured regions against the Temporal Cloud API.
+func (r *namespaceResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Skip on destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Skip if the client is not configured (e.g., during early validation or provider config errors).
+	if r.client == nil {
+		return
+	}
+
+	var plan namespaceResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Skip if regions are unknown (computed values not yet resolved).
+	if plan.Regions.IsUnknown() {
+		return
+	}
+
+	configuredRegions, d := getRegionsFromModel(ctx, &plan)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(configuredRegions) == 0 {
+		return
+	}
+
+	regionsResp, err := r.client.CloudService().GetRegions(ctx, &cloudservicev1.GetRegionsRequest{})
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Unable to Validate Regions",
+			fmt.Sprintf("Failed to fetch available regions from Temporal Cloud API: %s. Region validation will be skipped.", err.Error()),
+		)
+		return
+	}
+
+	validRegions := make(map[string]bool, len(regionsResp.GetRegions()))
+	for _, region := range regionsResp.GetRegions() {
+		validRegions[region.GetId()] = true
+	}
+
+	for _, region := range configuredRegions {
+		if !validRegions[region] {
+			resp.Diagnostics.AddError(
+				"Invalid Region",
+				fmt.Sprintf("Region %q is not a valid Temporal Cloud region. Use the temporalcloud_regions data source or see https://docs.temporal.io/cloud/regions for the list of available regions.", region),
+			)
+		}
 	}
 }
 

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -57,8 +57,8 @@ import (
 	namespacev1 "go.temporal.io/cloud-sdk/api/namespace/v1"
 
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
-	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/provider/validators"
+	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
 )
 
 const (

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -58,6 +58,7 @@ import (
 
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
+	"github.com/temporalio/terraform-provider-temporalcloud/internal/provider/validators"
 )
 
 const (
@@ -202,6 +203,9 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				Required:    true,
 				CustomType: internaltypes.UnorderedStringListType{
 					ListType: basetypes.ListType{ElemType: basetypes.StringType{}},
+				},
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(validators.Region()),
 				},
 			},
 			"accepted_client_ca": schema.StringAttribute{

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -129,6 +129,31 @@ resource "temporalcloud_namespace" "terraform" {
 	})
 }
 
+func TestAccNamespaceInvalidRegionAPIValidation(t *testing.T) {
+	config := `
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_namespace" "terraform" {
+  name               = "tf-invalid-api-region"
+  regions            = ["aws-us-fake-99"]
+  api_key_auth       = true
+  retention_days     = 7
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Invalid Region`),
+			},
+		},
+	})
+}
+
 func TestAccBasicNamespaceWithApiKeyAuth(t *testing.T) {
 	name := fmt.Sprintf("%s-%s", "tf-basic-namespace", randomString(10))
 	config := func(name string, retention int) string {

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -104,6 +104,31 @@ PEM
 
 }
 
+func TestAccNamespaceInvalidRegion(t *testing.T) {
+	config := `
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_namespace" "terraform" {
+  name               = "tf-invalid-region"
+  regions            = ["invalid-region"]
+  api_key_auth       = true
+  retention_days     = 7
+}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Invalid Region Format`),
+			},
+		},
+	})
+}
+
 func TestAccBasicNamespaceWithApiKeyAuth(t *testing.T) {
 	name := fmt.Sprintf("%s-%s", "tf-basic-namespace", randomString(10))
 	config := func(name string, retention int) string {

--- a/internal/provider/validators/region_validator.go
+++ b/internal/provider/validators/region_validator.go
@@ -1,0 +1,81 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// Known valid Temporal Cloud regions as of 2026.
+// See https://docs.temporal.io/cloud/regions
+// This list is sourced from the Temporal Cloud API via data.temporalcloud_regions.
+var validRegions = map[string]bool{
+	// AWS regions (14)
+	"aws-ap-northeast-1": true, // Tokyo
+	"aws-ap-northeast-2": true, // Seoul
+	"aws-ap-south-1":     true, // Mumbai
+	"aws-ap-south-2":     true, // Hyderabad
+	"aws-ap-southeast-1": true, // Singapore
+	"aws-ap-southeast-2": true, // Sydney
+	"aws-ca-central-1":   true, // Canada
+	"aws-eu-central-1":   true, // Frankfurt
+	"aws-eu-west-1":      true, // Ireland
+	"aws-eu-west-2":      true, // London
+	"aws-sa-east-1":      true, // Sao Paulo
+	"aws-us-east-1":      true, // N. Virginia
+	"aws-us-east-2":      true, // Ohio
+	"aws-us-west-2":      true, // Oregon
+	// GCP regions (5)
+	"gcp-asia-south1":   true, // Mumbai
+	"gcp-europe-west3":  true, // Frankfurt
+	"gcp-us-central1":   true, // Iowa
+	"gcp-us-east4":      true, // N. Virginia
+	"gcp-us-west1":      true, // Oregon
+}
+
+// regionFormatPattern validates that a region follows the expected format
+var regionFormatPattern = regexp.MustCompile(`^(aws|gcp)-[a-z0-9-]+$`)
+
+type regionValidator struct{}
+
+// Region returns a validator that checks if a string is a valid Temporal Cloud region.
+func Region() validator.String {
+	return &regionValidator{}
+}
+
+func (v *regionValidator) Description(ctx context.Context) string {
+	return "must be a valid Temporal Cloud region (e.g., aws-us-east-1, gcp-us-central1)"
+}
+
+func (v *regionValidator) MarkdownDescription(ctx context.Context) string {
+	return "must be a valid Temporal Cloud region (e.g., `aws-us-east-1`, `gcp-us-central1`). See [available regions](https://docs.temporal.io/cloud/regions)."
+}
+
+func (v *regionValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+
+	// First check format
+	if !regionFormatPattern.MatchString(value) {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid Region Format",
+			fmt.Sprintf("Region %q does not match expected format. Regions must be prefixed with cloud provider (e.g., aws-us-east-1, gcp-us-central1). See https://docs.temporal.io/cloud/regions", value),
+		)
+		return
+	}
+
+	// Then check against known valid regions
+	if !validRegions[value] {
+		resp.Diagnostics.AddAttributeWarning(
+			req.Path,
+			"Unknown Region",
+			fmt.Sprintf("Region %q is not in the list of known Temporal Cloud regions. This may be a new region or a typo. See https://docs.temporal.io/cloud/regions for the current list.", value),
+		)
+	}
+}

--- a/internal/provider/validators/region_validator.go
+++ b/internal/provider/validators/region_validator.go
@@ -28,14 +28,14 @@ var validRegions = map[string]bool{
 	"aws-us-east-2":      true, // Ohio
 	"aws-us-west-2":      true, // Oregon
 	// GCP regions (5)
-	"gcp-asia-south1":   true, // Mumbai
-	"gcp-europe-west3":  true, // Frankfurt
-	"gcp-us-central1":   true, // Iowa
-	"gcp-us-east4":      true, // N. Virginia
-	"gcp-us-west1":      true, // Oregon
+	"gcp-asia-south1":  true, // Mumbai
+	"gcp-europe-west3": true, // Frankfurt
+	"gcp-us-central1":  true, // Iowa
+	"gcp-us-east4":     true, // N. Virginia
+	"gcp-us-west1":     true, // Oregon
 }
 
-// regionFormatPattern validates that a region follows the expected format
+// regionFormatPattern validates that a region follows the expected format.
 var regionFormatPattern = regexp.MustCompile(`^(aws|gcp)-[a-z0-9-]+$`)
 
 type regionValidator struct{}

--- a/internal/provider/validators/region_validator.go
+++ b/internal/provider/validators/region_validator.go
@@ -8,74 +8,38 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-// Known valid Temporal Cloud regions as of 2026.
-// See https://docs.temporal.io/cloud/regions
-// This list is sourced from the Temporal Cloud API via data.temporalcloud_regions.
-var validRegions = map[string]bool{
-	// AWS regions (14)
-	"aws-ap-northeast-1": true, // Tokyo
-	"aws-ap-northeast-2": true, // Seoul
-	"aws-ap-south-1":     true, // Mumbai
-	"aws-ap-south-2":     true, // Hyderabad
-	"aws-ap-southeast-1": true, // Singapore
-	"aws-ap-southeast-2": true, // Sydney
-	"aws-ca-central-1":   true, // Canada
-	"aws-eu-central-1":   true, // Frankfurt
-	"aws-eu-west-1":      true, // Ireland
-	"aws-eu-west-2":      true, // London
-	"aws-sa-east-1":      true, // Sao Paulo
-	"aws-us-east-1":      true, // N. Virginia
-	"aws-us-east-2":      true, // Ohio
-	"aws-us-west-2":      true, // Oregon
-	// GCP regions (5)
-	"gcp-asia-south1":  true, // Mumbai
-	"gcp-europe-west3": true, // Frankfurt
-	"gcp-us-central1":  true, // Iowa
-	"gcp-us-east4":     true, // N. Virginia
-	"gcp-us-west1":     true, // Oregon
-}
-
-// regionFormatPattern validates that a region follows the expected format.
 var regionFormatPattern = regexp.MustCompile(`^(aws|gcp)-[a-z0-9-]+$`)
 
-type regionValidator struct{}
+type regionFormatValidator struct{}
 
-// Region returns a validator that checks if a string is a valid Temporal Cloud region.
-func Region() validator.String {
-	return &regionValidator{}
+// RegionFormat returns a validator that checks if a string matches the expected
+// Temporal Cloud region format (e.g., aws-us-east-1, gcp-us-central1).
+// It does not verify that the region actually exists — that is handled by
+// ModifyPlan via the GetRegions API.
+func RegionFormat() validator.String {
+	return &regionFormatValidator{}
 }
 
-func (v *regionValidator) Description(ctx context.Context) string {
-	return "must be a valid Temporal Cloud region (e.g., aws-us-east-1, gcp-us-central1)"
+func (v *regionFormatValidator) Description(ctx context.Context) string {
+	return "must be a valid Temporal Cloud region format (e.g., aws-us-east-1, gcp-us-central1)"
 }
 
-func (v *regionValidator) MarkdownDescription(ctx context.Context) string {
-	return "must be a valid Temporal Cloud region (e.g., `aws-us-east-1`, `gcp-us-central1`). See [available regions](https://docs.temporal.io/cloud/regions)."
+func (v *regionFormatValidator) MarkdownDescription(ctx context.Context) string {
+	return "must be a valid Temporal Cloud region format (e.g., `aws-us-east-1`, `gcp-us-central1`). See [available regions](https://docs.temporal.io/cloud/regions)."
 }
 
-func (v *regionValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+func (v *regionFormatValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 
 	value := req.ConfigValue.ValueString()
 
-	// First check format
 	if !regionFormatPattern.MatchString(value) {
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Invalid Region Format",
 			fmt.Sprintf("Region %q does not match expected format. Regions must be prefixed with cloud provider (e.g., aws-us-east-1, gcp-us-central1). See https://docs.temporal.io/cloud/regions", value),
-		)
-		return
-	}
-
-	// Then check against known valid regions
-	if !validRegions[value] {
-		resp.Diagnostics.AddAttributeWarning(
-			req.Path,
-			"Unknown Region",
-			fmt.Sprintf("Region %q is not in the list of known Temporal Cloud regions. This may be a new region or a typo. See https://docs.temporal.io/cloud/regions for the current list.", value),
 		)
 	}
 }


### PR DESCRIPTION
Validates regions during plan:
- Must have cloud provider prefix (aws-*/gcp-*)
- Warns if region not in known list

Fixes #265