### PR TITLE
Fix developer account_access mapping

### DIFF
--- a/internal/provider/enums/identity.go
+++ b/internal/provider/enums/identity.go
@@ -89,6 +89,28 @@ func FromAccountAccessRole(r identity.AccountAccess_Role) (string, error) {
 	}
 }
 
+// FromAccountAccess extracts the role string from an AccountAccess object.
+// It first checks the Role enum field, and if that is UNSPECIFIED, falls back
+// to the deprecated RoleDeprecated string field. This handles the case where
+// the API returns the role in the deprecated field for some account types.
+func FromAccountAccess(access *identity.AccountAccess) (string, error) {
+	if access == nil {
+		return "none", nil
+	}
+
+	// First try the enum field
+	if access.GetRole() != identity.AccountAccess_ROLE_UNSPECIFIED {
+		return FromAccountAccessRole(access.GetRole())
+	}
+
+	// Fall back to the deprecated string field if the enum is unspecified
+	if deprecated := access.GetRoleDeprecated(); deprecated != "" {
+		return strings.ToLower(deprecated), nil
+	}
+
+	return "none", nil
+}
+
 func ToNamespaceAccessPermission(s string) (identity.NamespaceAccess_Permission, error) {
 	switch strings.ToLower(s) {
 	case "admin":

--- a/internal/provider/enums/identity.go
+++ b/internal/provider/enums/identity.go
@@ -103,7 +103,8 @@ func FromAccountAccess(access *identity.AccountAccess) (string, error) {
 		return FromAccountAccessRole(access.GetRole())
 	}
 
-	// Fall back to the deprecated string field if the enum is unspecified
+	// Fall back to the deprecated string field if the enum is unspecified.
+	//nolint:staticcheck // SA1019: RoleDeprecated still used by older Temporal Cloud accounts.
 	if deprecated := access.GetRoleDeprecated(); deprecated != "" {
 		return strings.ToLower(deprecated), nil
 	}

--- a/internal/provider/group_access_resource.go
+++ b/internal/provider/group_access_resource.go
@@ -365,7 +365,7 @@ func updateGroupAccessModel(ctx context.Context, state *groupAccessResourceModel
 
 	state.ID = types.StringValue(group.Id)
 
-	role, err := enums.FromAccountAccessRole(group.GetSpec().GetAccess().GetAccountAccess().GetRole())
+	role, err := enums.FromAccountAccess(group.GetSpec().GetAccess().GetAccountAccess())
 	if err != nil {
 		diags.AddError("Failed to convert account access role", err.Error())
 		return diags

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -538,7 +538,7 @@ func updateServiceAccountModelFromSpec(ctx context.Context, state *serviceAccoun
 		state.NamespaceAccesses = types.SetNull(types.ObjectType{AttrTypes: serviceAccountNamespaceAccessAttrs})
 	} else {
 		// Handle account-scoped service account
-		role, err := enums.FromAccountAccessRole(serviceAccount.GetSpec().GetAccess().GetAccountAccess().GetRole())
+		role, err := enums.FromAccountAccess(serviceAccount.GetSpec().GetAccess().GetAccountAccess())
 		if err != nil {
 			diags.AddError("Failed to convert account access role", err.Error())
 		}

--- a/internal/provider/service_accounts_datasource.go
+++ b/internal/provider/service_accounts_datasource.go
@@ -252,7 +252,7 @@ func serviceAccountToServiceAccountDataModel(ctx context.Context, sa *identityv1
 		serviceAccountModel.NamespaceAccesses = types.SetNull(types.ObjectType{AttrTypes: serviceAccountNamespaceAccessAttrs})
 	} else {
 		// Handle account-scoped service account
-		role, err := enums.FromAccountAccessRole(sa.GetSpec().GetAccess().GetAccountAccess().GetRole())
+		role, err := enums.FromAccountAccess(sa.GetSpec().GetAccess().GetAccountAccess())
 		if err != nil {
 			diags.AddError("Failed to convert account access role", err.Error())
 			return nil, diags

--- a/internal/provider/user_datasource_model.go
+++ b/internal/provider/user_datasource_model.go
@@ -50,7 +50,7 @@ func userToUserDataModel(ctx context.Context, sa *identityv1.User) (*userDataMod
 		UpdatedAt: types.StringValue(sa.GetLastModifiedTime().AsTime().GoString()),
 	}
 
-	role, err := enums.FromAccountAccessRole(sa.GetSpec().GetAccess().GetAccountAccess().GetRole())
+	role, err := enums.FromAccountAccess(sa.GetSpec().GetAccess().GetAccountAccess())
 	if err != nil {
 		diags.AddError("Failed to convert account access role", err.Error())
 		return nil, diags

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -440,7 +440,7 @@ func updateUserModelFromSpec(ctx context.Context, state *userResourceModel, user
 	}
 	state.State = types.StringValue(stateStr)
 	state.Email = types.StringValue(user.GetSpec().GetEmail())
-	role, err := enums.FromAccountAccessRole(user.GetSpec().GetAccess().GetAccountAccess().GetRole())
+	role, err := enums.FromAccountAccess(user.GetSpec().GetAccess().GetAccountAccess())
 	if err != nil {
 		diags.AddError("Failed to convert account access role", err.Error())
 		return diags


### PR DESCRIPTION
Fixes import of service accounts with developer role showing account_access as "none".

Checks both new Role enum and deprecated RoleDeprecated field.

Fixes #296