### PR TITLE
switch email to use a case insensetive string (fixes #397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
 ## 0.1.0 (Unreleased)
 
-BUG FIXES:
-
-- **User resource/datasource**: Treat `email` as case-insensitive so that Temporal Cloud API normalization to lowercase no longer causes "Provider produced inconsistent result after apply" ([#397](https://github.com/temporalio/terraform-provider-temporalcloud/issues/397)).
-
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.1.0 (Unreleased)
 
+BUG FIXES:
+
+- **User resource/datasource**: Treat `email` as case-insensitive so that Temporal Cloud API normalization to lowercase no longer causes "Provider produced inconsistent result after apply" ([#397](https://github.com/temporalio/terraform-provider-temporalcloud/issues/397)).
+
 FEATURES:

--- a/internal/provider/user_datasource_model.go
+++ b/internal/provider/user_datasource_model.go
@@ -20,7 +20,7 @@ type (
 
 	userDataModel struct {
 		ID                types.String                             `tfsdk:"id"`
-		Email             types.String                             `tfsdk:"email"`
+		Email             internaltypes.CaseInsensitiveStringValue `tfsdk:"email"`
 		State             types.String                             `tfsdk:"state"`
 		AccountAccess     internaltypes.CaseInsensitiveStringValue `tfsdk:"account_access"`
 		NamespaceAccesses types.Set                                `tfsdk:"namespace_accesses"`
@@ -44,7 +44,7 @@ func userToUserDataModel(ctx context.Context, sa *identityv1.User) (*userDataMod
 
 	userModel := &userDataModel{
 		ID:        types.StringValue(sa.Id),
-		Email:     types.StringValue(sa.GetSpec().GetEmail()),
+		Email:     internaltypes.CaseInsensitiveString(sa.GetSpec().GetEmail()),
 		State:     types.StringValue(stateStr),
 		CreatedAt: types.StringValue(sa.GetCreatedTime().AsTime().GoString()),
 		UpdatedAt: types.StringValue(sa.GetLastModifiedTime().AsTime().GoString()),
@@ -109,6 +109,7 @@ func userSchema(idRequired bool) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"id": idAttribute,
 		"email": schema.StringAttribute{
+			CustomType:  internaltypes.CaseInsensitiveStringType{},
 			Description: "The email of the User.",
 			Computed:    true,
 		},

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -107,7 +107,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"email": schema.StringAttribute{
-				CustomType: internaltypes.CaseInsensitiveStringType{},
+				CustomType:  internaltypes.CaseInsensitiveStringType{},
 				Description: "The email address for the user.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -38,7 +38,7 @@ type (
 	userResourceModel struct {
 		ID                types.String                             `tfsdk:"id"`
 		State             types.String                             `tfsdk:"state"`
-		Email             types.String                             `tfsdk:"email"`
+		Email             internaltypes.CaseInsensitiveStringValue `tfsdk:"email"`
 		AccountAccess     internaltypes.CaseInsensitiveStringValue `tfsdk:"account_access"`
 		NamespaceAccesses types.Set                                `tfsdk:"namespace_accesses"`
 
@@ -107,6 +107,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"email": schema.StringAttribute{
+				CustomType: internaltypes.CaseInsensitiveStringType{},
 				Description: "The email address for the user.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
@@ -439,7 +440,7 @@ func updateUserModelFromSpec(ctx context.Context, state *userResourceModel, user
 		return diags
 	}
 	state.State = types.StringValue(stateStr)
-	state.Email = types.StringValue(user.GetSpec().GetEmail())
+	state.Email = internaltypes.CaseInsensitiveString(user.GetSpec().GetEmail())
 	role, err := enums.FromAccountAccessRole(user.GetSpec().GetAccess().GetAccountAccess().GetRole())
 	if err != nil {
 		diags.AddError("Failed to convert account access role", err.Error())

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -50,6 +51,17 @@ func createRandomEmail() string {
 	return fmt.Sprintf("%s+terraformprovider-%s@%s", emailBaseAddr, randomString(10), emailDomain)
 }
 
+// createCapitalizedEmail returns an email with uppercase letters in the local part.
+// Used to verify that API normalization to lowercase does not cause "inconsistent result" (issue #397).
+func createCapitalizedEmail() string {
+	base := createRandomEmail()
+	at := strings.Index(base, "@")
+	if at < 0 {
+		return base
+	}
+	return strings.ToUpper(base[:at]) + base[at:]
+}
+
 func TestAccBasicUser(t *testing.T) {
 	emailAddr := createRandomEmail()
 	config := func(email string, role string) string {
@@ -78,6 +90,41 @@ resource "temporalcloud_user" "terraform" {
 			},
 			{
 				Config: config(emailAddr, "admin"),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_user.terraform",
+			},
+		},
+	})
+}
+
+// TestAccUserWithCapitalizedEmail verifies that creating a user with capitalization in the email
+// does not produce "Provider produced inconsistent result after apply" (issue #397).
+// The Temporal Cloud API normalizes email to lowercase; the provider treats email as case-insensitive.
+func TestAccUserWithCapitalizedEmail(t *testing.T) {
+	emailAddr := createCapitalizedEmail()
+	config := func(email string, role string) string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_user" "terraform" {
+  email = "%s"
+  account_access = "%s"
+}`, email, role)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(emailAddr, "read"),
 			},
 			{
 				ImportState:       true,


### PR DESCRIPTION
Had AI add test and comments to changlog

## What was changed
Switch Email to use a case insensitive string so when terraform compares bill@bill.com with Bill@bill.com they are equivalent (API auto lowercases emails as is standard, this allows users to include capitalization in their email strings) 

## Why?
User reported error in ticket system

## Checklist

1. Closes #397 

2. How was this tested:
Test adding an email that has multi-case in it

3. Any docs updates needed?
Don't think it is needed
