### PR TITLE
Wait for a successful get of namespace during creation

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -727,19 +727,15 @@ func (r *namespaceResource) ImportState(ctx context.Context, req resource.Import
 
 // waitForNamespaceAvailableConfig contains configuration for polling behavior.
 type waitForNamespaceAvailableConfig struct {
-	initialDelay     time.Duration
-	retryInterval    time.Duration
-	maxRetryInterval time.Duration
-	maxAttempts      int
+	retryInterval time.Duration
+	maxAttempts   int
 }
 
 // defaultWaitForNamespaceAvailableConfig returns the default polling configuration.
 func defaultWaitForNamespaceAvailableConfig() waitForNamespaceAvailableConfig {
 	return waitForNamespaceAvailableConfig{
-		initialDelay:     time.Second,
-		retryInterval:    10 * time.Second,
-		maxRetryInterval: 30 * time.Second,
-		maxAttempts:      5,
+		retryInterval: 10 * time.Second,
+		maxAttempts:   12,
 	}
 }
 
@@ -753,15 +749,7 @@ func waitForNamespaceAvailable(ctx context.Context, client *client.Client, names
 func waitForNamespaceAvailableWithConfig(ctx context.Context, getNamespaceFunc func(context.Context, *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error), namespaceID string, config waitForNamespaceAvailableConfig) (*namespacev1.Namespace, error) {
 	ctx = tflog.SetField(ctx, "namespace_id", namespaceID)
 
-	// Initial delay before first attempt
-	select {
-	case <-time.After(config.initialDelay):
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-
 	retryInterval := config.retryInterval
-	maxRetryInterval := config.maxRetryInterval
 	maxAttempts := config.maxAttempts
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -779,8 +767,8 @@ func waitForNamespaceAvailableWithConfig(ctx context.Context, getNamespaceFunc f
 		}
 
 		// Check if it's a PermissionDenied error that we should retry, or a different error we should fail on
-		if status.Code(err) == codes.PermissionDenied {
-			tflog.Debug(ctx, "namespace not yet accessible due to permissions, retrying", map[string]any{
+		if status.Code(err) == codes.PermissionDenied || status.Code(err) == codes.NotFound {
+			tflog.Debug(ctx, "namespace not yet accessible, retrying", map[string]any{
 				"attempt":  attempt,
 				"retry_in": retryInterval.String(),
 				"error":    err.Error(),
@@ -802,11 +790,6 @@ func waitForNamespaceAvailableWithConfig(ctx context.Context, getNamespaceFunc f
 		// Wait before next retry, respecting context cancellation
 		select {
 		case <-time.After(retryInterval):
-			// Exponential backoff: double the interval but cap at maxRetryInterval
-			retryInterval *= 2
-			if retryInterval > maxRetryInterval {
-				retryInterval = maxRetryInterval
-			}
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -464,15 +464,13 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	ns, err := r.client.CloudService().GetNamespace(ctx, &cloudservicev1.GetNamespaceRequest{
-		Namespace: svcResp.Namespace,
-	})
+	ns, err := waitForNamespaceAvailable(ctx, r.client, svcResp.Namespace)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get namespace after creation", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(updateModelFromSpec(ctx, &plan, ns.Namespace)...)
+	resp.Diagnostics.Append(updateModelFromSpec(ctx, &plan, ns)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -725,6 +723,96 @@ func (r *namespaceResource) Delete(ctx context.Context, req resource.DeleteReque
 
 func (r *namespaceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// waitForNamespaceAvailableConfig contains configuration for polling behavior.
+type waitForNamespaceAvailableConfig struct {
+	initialDelay     time.Duration
+	retryInterval    time.Duration
+	maxRetryInterval time.Duration
+	maxAttempts      int
+}
+
+// defaultWaitForNamespaceAvailableConfig returns the default polling configuration.
+func defaultWaitForNamespaceAvailableConfig() waitForNamespaceAvailableConfig {
+	return waitForNamespaceAvailableConfig{
+		initialDelay:     time.Second,
+		retryInterval:    10 * time.Second,
+		maxRetryInterval: 30 * time.Second,
+		maxAttempts:      5,
+	}
+}
+
+func waitForNamespaceAvailable(ctx context.Context, client *client.Client, namespaceID string) (*namespacev1.Namespace, error) {
+	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
+		return client.CloudService().GetNamespace(ctx, req)
+	}
+	return waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, namespaceID, defaultWaitForNamespaceAvailableConfig())
+}
+
+func waitForNamespaceAvailableWithConfig(ctx context.Context, getNamespaceFunc func(context.Context, *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error), namespaceID string, config waitForNamespaceAvailableConfig) (*namespacev1.Namespace, error) {
+	ctx = tflog.SetField(ctx, "namespace_id", namespaceID)
+
+	// Initial delay before first attempt
+	select {
+	case <-time.After(config.initialDelay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	retryInterval := config.retryInterval
+	maxRetryInterval := config.maxRetryInterval
+	maxAttempts := config.maxAttempts
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		tflog.Debug(ctx, "attempting to get namespace", map[string]any{
+			"attempt": attempt,
+		})
+
+		ns, err := getNamespaceFunc(ctx, &cloudservicev1.GetNamespaceRequest{
+			Namespace: namespaceID,
+		})
+
+		if err == nil {
+			tflog.Debug(ctx, "namespace successfully retrieved")
+			return ns.Namespace, nil
+		}
+
+		// Check if it's a PermissionDenied error that we should retry, or a different error we should fail on
+		if status.Code(err) == codes.PermissionDenied {
+			tflog.Debug(ctx, "namespace not yet accessible due to permissions, retrying", map[string]any{
+				"attempt":  attempt,
+				"retry_in": retryInterval.String(),
+				"error":    err.Error(),
+			})
+		} else {
+			// For non-PermissionDenied errors, fail immediately
+			tflog.Error(ctx, "failed to get namespace with non-retryable error", map[string]any{
+				"attempt": attempt,
+				"error":   err.Error(),
+			})
+			return nil, fmt.Errorf("failed to get namespace: %w", err)
+		}
+
+		// Check if we have more attempts left
+		if attempt >= maxAttempts {
+			break
+		}
+
+		// Wait before next retry, respecting context cancellation
+		select {
+		case <-time.After(retryInterval):
+			// Exponential backoff: double the interval but cap at maxRetryInterval
+			retryInterval *= 2
+			if retryInterval > maxRetryInterval {
+				retryInterval = maxRetryInterval
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return nil, fmt.Errorf("namespace %s not available after %d attempts", namespaceID, maxAttempts)
 }
 
 func getRegionsFromModel(ctx context.Context, plan *namespaceResourceModel) ([]string, diag.Diagnostics) {

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"go.temporal.io/cloud-sdk/api/namespace/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	cloudservicev1 "go.temporal.io/cloud-sdk/api/cloudservice/v1"
 
@@ -981,4 +983,182 @@ PEM
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+func testConfig() waitForNamespaceAvailableConfig {
+	return waitForNamespaceAvailableConfig{
+		initialDelay:     10 * time.Millisecond,
+		retryInterval:    10 * time.Millisecond,
+		maxRetryInterval: 50 * time.Millisecond,
+		maxAttempts:      5,
+	}
+}
+
+func TestWaitForNamespaceAvailableSuccess(t *testing.T) {
+	callCount := 0
+	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
+		callCount++
+		return &cloudservicev1.GetNamespaceResponse{
+			Namespace: &namespace.Namespace{
+				Namespace: "test-namespace-id",
+				Spec: &namespace.NamespaceSpec{
+					Name: "test-namespace",
+				},
+			},
+		}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", testConfig())
+
+	if err != nil {
+		t.Fatalf("Expected success, got error: %v", err)
+	}
+
+	if ns == nil {
+		t.Fatal("Expected namespace, got nil")
+	}
+
+	if ns.Namespace != "test-namespace-id" {
+		t.Errorf("Expected namespace ID 'test-namespace-id', got '%s'", ns.Namespace)
+	}
+
+	if callCount != 1 {
+		t.Errorf("Expected 1 API call, got %d", callCount)
+	}
+}
+
+func TestWaitForNamespaceAvailableRetriesOnPermissionDenied(t *testing.T) {
+	attempts := 0
+	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
+		attempts++
+		if attempts < 3 {
+			// Return permission denied for first 2 attempts
+			return nil, status.Error(codes.PermissionDenied, "permission denied")
+		}
+		// Success on 3rd attempt
+		return &cloudservicev1.GetNamespaceResponse{
+			Namespace: &namespace.Namespace{
+				Namespace: "test-namespace-id",
+				Spec: &namespace.NamespaceSpec{
+					Name: "test-namespace",
+				},
+			},
+		}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", testConfig())
+
+	if err != nil {
+		t.Fatalf("Expected success after retries, got error: %v", err)
+	}
+
+	if ns == nil {
+		t.Fatal("Expected namespace, got nil")
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestWaitForNamespaceAvailableFailsOnNonRetryableError(t *testing.T) {
+	callCount := 0
+	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
+		callCount++
+		// Return a non-retryable error (not permission denied)
+		return nil, status.Error(codes.Internal, "internal server error")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", testConfig())
+
+	if err == nil {
+		t.Fatal("Expected error, got success")
+	}
+
+	if ns != nil {
+		t.Error("Expected nil namespace, got non-nil")
+	}
+
+	if callCount != 1 {
+		t.Errorf("Expected 1 API call (should fail immediately), got %d", callCount)
+	}
+
+	// Check that the error message indicates it failed to get namespace
+	if !strings.Contains(err.Error(), "failed to get namespace") {
+		t.Errorf("Expected error message to contain 'failed to get namespace', got: %v", err)
+	}
+}
+
+func TestWaitForNamespaceAvailableContextTimeout(t *testing.T) {
+	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
+		// Always return permission denied to keep retrying
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
+
+	// Very short timeout to ensure context cancellation
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", testConfig())
+
+	if err == nil {
+		t.Fatal("Expected timeout error, got success")
+	}
+
+	if ns != nil {
+		t.Error("Expected nil namespace, got non-nil")
+	}
+
+	// Should be context deadline exceeded
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Expected context deadline exceeded error, got: %v", err)
+	}
+}
+
+func TestWaitForNamespaceAvailableMaxAttemptsReached(t *testing.T) {
+	callCount := 0
+	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
+		callCount++
+		// Always return permission denied
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	config := waitForNamespaceAvailableConfig{
+		initialDelay:     10 * time.Millisecond,
+		retryInterval:    10 * time.Millisecond,
+		maxRetryInterval: 50 * time.Millisecond,
+		maxAttempts:      3, // Small number for fast testing
+	}
+
+	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", config)
+
+	if err == nil {
+		t.Fatal("Expected max attempts error, got success")
+	}
+
+	if ns != nil {
+		t.Error("Expected nil namespace, got non-nil")
+	}
+
+	// Should hit the max attempts limit
+	if callCount != 3 {
+		t.Errorf("Expected exactly 3 attempts, got %d", callCount)
+	}
+
+	// Check error message indicates max attempts reached
+	if !strings.Contains(err.Error(), "not available after") && !strings.Contains(err.Error(), "attempts") {
+		t.Errorf("Expected error message to indicate max attempts reached, got: %v", err)
+	}
 }

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -987,10 +987,8 @@ PEM
 
 func testConfig() waitForNamespaceAvailableConfig {
 	return waitForNamespaceAvailableConfig{
-		initialDelay:     10 * time.Millisecond,
-		retryInterval:    10 * time.Millisecond,
-		maxRetryInterval: 50 * time.Millisecond,
-		maxAttempts:      5,
+		retryInterval: 10 * time.Millisecond,
+		maxAttempts:   5,
 	}
 }
 
@@ -1067,6 +1065,43 @@ func TestWaitForNamespaceAvailableRetriesOnPermissionDenied(t *testing.T) {
 	}
 }
 
+func TestWaitForNamespaceAvailableRetriesOnNotFound(t *testing.T) {
+	attempts := 0
+	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
+		attempts++
+		if attempts < 3 {
+			// Return not found for first 2 attempts
+			return nil, status.Error(codes.NotFound, "namespace not found")
+		}
+		// Success on 3rd attempt
+		return &cloudservicev1.GetNamespaceResponse{
+			Namespace: &namespace.Namespace{
+				Namespace: "test-namespace-id",
+				Spec: &namespace.NamespaceSpec{
+					Name: "test-namespace",
+				},
+			},
+		}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", testConfig())
+
+	if err != nil {
+		t.Fatalf("Expected success after retries, got error: %v", err)
+	}
+
+	if ns == nil {
+		t.Fatal("Expected namespace, got nil")
+	}
+
+	if attempts != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attempts)
+	}
+}
+
 func TestWaitForNamespaceAvailableFailsOnNonRetryableError(t *testing.T) {
 	callCount := 0
 	getNamespaceFunc := func(ctx context.Context, req *cloudservicev1.GetNamespaceRequest) (*cloudservicev1.GetNamespaceResponse, error) {
@@ -1105,10 +1140,16 @@ func TestWaitForNamespaceAvailableContextTimeout(t *testing.T) {
 	}
 
 	// Very short timeout to ensure context cancellation
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
 
-	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", testConfig())
+	// Use config with longer intervals to ensure timeout occurs before max attempts
+	config := waitForNamespaceAvailableConfig{
+		retryInterval: 20 * time.Millisecond, // Longer than context timeout
+		maxAttempts:   10,                    // High number that won't be reached
+	}
+
+	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", config)
 
 	if err == nil {
 		t.Fatal("Expected timeout error, got success")
@@ -1136,10 +1177,8 @@ func TestWaitForNamespaceAvailableMaxAttemptsReached(t *testing.T) {
 	defer cancel()
 
 	config := waitForNamespaceAvailableConfig{
-		initialDelay:     10 * time.Millisecond,
-		retryInterval:    10 * time.Millisecond,
-		maxRetryInterval: 50 * time.Millisecond,
-		maxAttempts:      3, // Small number for fast testing
+		retryInterval: 10 * time.Millisecond,
+		maxAttempts:   3, // Small number for fast testing
 	}
 
 	ns, err := waitForNamespaceAvailableWithConfig(ctx, getNamespaceFunc, "test-namespace-id", config)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
When creating a namespace, poll for a successful read of the namespace before returning.
<!-- Describe what has changed in this PR -->

## Why?
When a non-admin role is used in the creation of a namespace, there is a delay between creation of the namespace and successful authorization to the namespace.  For instance, if the provider is configured using a service account with a developer role, actions immediately following creation of a new namespace could fail.  This change ensures the namespace can be read before the creation is completed.
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/terraform-provider-temporalcloud/issues/391

2. How was this tested:
Tested using a SA with developer role against prod.  However, my first attempt failed due to the auth. propagation happening too quickly, so I tested using a build of the provider with the `client.AwaitAsyncOperation` on the `CreateNameSpace` removed.
<!--- Please describe how you tested your changes/how we can test them -->

4. Any docs updates needed?
No.
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
