### PR TITLE
Support on-demand during ns create, block unsetting capacity

### DIFF
--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -380,7 +380,7 @@ func (r *namespaceResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if !state.Capacity.IsNull() && plan.Capacity.IsNull() {
+		if !state.Capacity.IsNull() && (plan.Capacity.IsNull() || plan.Capacity.IsZero(ctx)) {
 			resp.Diagnostics.AddError(
 				"capacity cannot be removed once set",
 				`capacity cannot be removed once set; to revert to on-demand, explicitly set capacity { mode = "on_demand" }`,
@@ -627,7 +627,7 @@ func (r *namespaceResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	if !state.Capacity.IsNull() && plan.Capacity.IsNull() {
+	if !state.Capacity.IsNull() && (plan.Capacity.IsNull() || plan.Capacity.IsZero(ctx)) {
 		resp.Diagnostics.AddError(
 			"capacity cannot be removed once set",
 			`capacity cannot be removed once set; to revert to on-demand, explicitly set capacity { mode = "on_demand" }`,

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -373,6 +373,22 @@ func (r *namespaceResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 		return
 	}
 
+	// On update (state exists), reject removing capacity once set.
+	if !req.State.Raw.IsNull() {
+		var state namespaceResourceModel
+		resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if !state.Capacity.IsNull() && plan.Capacity.IsNull() {
+			resp.Diagnostics.AddError(
+				"capacity cannot be removed once set",
+				`capacity cannot be removed once set; to revert to on-demand, explicitly set capacity { mode = "on_demand" }`,
+			)
+			return
+		}
+	}
+
 	// Skip if regions are unknown (computed values not yet resolved).
 	if plan.Regions.IsUnknown() {
 		return
@@ -475,16 +491,22 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	if !plan.Capacity.IsNull() {
-		resp.Diagnostics.AddError("Capacity on namespace creation is not supported", "capacity should be null or not set when creating a namespace")
-		return
-		// This will be enabled when capacity on namespace creation is supported
-		// var d diag.Diagnostics
-		// capacitySpec, d := getCapacityFromModel(ctx, &plan)
-		// resp.Diagnostics.Append(d...)
-		// if resp.Diagnostics.HasError() {
-		// 	return
-		// }
-		// spec.CapacitySpec = capacitySpec
+		var capacity capacityModel
+		resp.Diagnostics.Append(plan.Capacity.As(ctx, &capacity, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if capacity.Mode.ValueString() != "on_demand" {
+			resp.Diagnostics.AddError("Provisioned capacity cannot be set on namespace creation", "capacity mode must be 'on_demand' when setting capacity during namespace creation")
+			return
+		}
+		var d diag.Diagnostics
+		capacitySpec, d := getCapacityFromModel(ctx, &plan)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		spec.CapacitySpec = capacitySpec
 	}
 
 	if !plan.ApiKeyAuth.ValueBool() && plan.AcceptedClientCA.IsNull() {
@@ -596,6 +618,20 @@ func (r *namespaceResource) Update(ctx context.Context, req resource.UpdateReque
 	var plan namespaceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var state namespaceResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !state.Capacity.IsNull() && plan.Capacity.IsNull() {
+		resp.Diagnostics.AddError(
+			"capacity cannot be removed once set",
+			`capacity cannot be removed once set; to revert to on-demand, explicitly set capacity { mode = "on_demand" }`,
+		)
 		return
 	}
 

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -497,7 +497,7 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 			return
 		}
 		if capacity.Mode.ValueString() != "on_demand" {
-			resp.Diagnostics.AddError("Provisioned capacity cannot be set on namespace creation", "capacity mode must be 'on_demand' when setting capacity during namespace creation")
+			resp.Diagnostics.AddError("Invalid capacity mode for namespace creation", "only 'on_demand' capacity mode is supported when creating a namespace")
 			return
 		}
 		var d diag.Diagnostics

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -530,31 +530,33 @@ PEM
 					return nil
 				},
 			},
-			{
-				// both auth methods
-				Config: config(configArgs{
-					Name:          name,
-					RetentionDays: 7,
-					ApiKeyAuth:    true,
-					TLSAuth:       true,
-				}),
-				Check: func(s *terraform.State) error {
-					id := s.RootModule().Resources["temporalcloud_namespace.test"].Primary.Attributes["id"]
-					conn := newConnection(t)
-					ns, err := conn.GetNamespace(context.Background(), &cloudservicev1.GetNamespaceRequest{
-						Namespace: id,
-					})
-					if err != nil {
-						return fmt.Errorf("failed to get namespace: %v", err)
-					}
-
-					spec := ns.Namespace.GetSpec()
-					if spec.GetCodecServer().GetEndpoint() != "" {
-						return fmt.Errorf("unexpected endpoint: %s", spec.GetCodecServer().GetEndpoint())
-					}
-					return nil
-				},
-			},
+			// TODO: re-enable once namespace endpoints support optional mTLS, making it safe for API key
+			// and mTLS clients to coexist on the same endpoint. The server currently rejects transitions
+			// from api_key_auth-only to both auth methods to avoid locking out API key clients.
+			// {
+			// 	// both auth methods
+			// 	Config: config(configArgs{
+			// 		Name:          name,
+			// 		RetentionDays: 7,
+			// 		ApiKeyAuth:    true,
+			// 		TLSAuth:       true,
+			// 	}),
+			// 	Check: func(s *terraform.State) error {
+			// 		id := s.RootModule().Resources["temporalcloud_namespace.test"].Primary.Attributes["id"]
+			// 		conn := newConnection(t)
+			// 		ns, err := conn.GetNamespace(context.Background(), &cloudservicev1.GetNamespaceRequest{
+			// 			Namespace: id,
+			// 		})
+			// 		if err != nil {
+			// 			return fmt.Errorf("failed to get namespace: %v", err)
+			// 		}
+			// 		spec := ns.Namespace.GetSpec()
+			// 		if spec.GetCodecServer().GetEndpoint() != "" {
+			// 			return fmt.Errorf("unexpected endpoint: %s", spec.GetCodecServer().GetEndpoint())
+			// 		}
+			// 		return nil
+			// 	},
+			// },
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -1059,7 +1059,7 @@ resource "temporalcloud_namespace" "test" {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`Provisioned capacity cannot be set on namespace creation`),
+				ExpectError: regexp.MustCompile(`Invalid capacity mode for namespace creation`),
 			},
 		},
 	})

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -1035,6 +1035,74 @@ PEM
 	})
 }
 
+func TestAccNamespaceCapacityProvisionedOnCreateErrors(t *testing.T) {
+	name := fmt.Sprintf("%s-%s", "tf-cap-create-err", randomString(10))
+	config := fmt.Sprintf(`
+provider "temporalcloud" {}
+
+resource "temporalcloud_namespace" "test" {
+  name           = "%s"
+  regions        = ["aws-us-east-1"]
+  api_key_auth   = true
+  retention_days = 7
+  capacity = {
+    mode  = "provisioned"
+    value = 2
+  }
+}`, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Provisioned capacity cannot be set on namespace creation`),
+			},
+		},
+	})
+}
+
+func TestAccNamespaceCapacityCannotBeUnset(t *testing.T) {
+	name := fmt.Sprintf("%s-%s", "tf-cap-unset", randomString(10))
+	withCapacity := fmt.Sprintf(`
+provider "temporalcloud" {}
+
+resource "temporalcloud_namespace" "test" {
+  name           = "%s"
+  regions        = ["aws-us-east-1"]
+  api_key_auth   = true
+  retention_days = 7
+  capacity = {
+    mode = "on_demand"
+  }
+}`, name)
+	withoutCapacity := fmt.Sprintf(`
+provider "temporalcloud" {}
+
+resource "temporalcloud_namespace" "test" {
+  name           = "%s"
+  regions        = ["aws-us-east-1"]
+  api_key_auth   = true
+  retention_days = 7
+}`, name)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: withCapacity,
+			},
+			{
+				Config:      withoutCapacity,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`capacity cannot be removed once set`),
+			},
+		},
+	})
+}
+
 func testConfig() waitForNamespaceAvailableConfig {
 	return waitForNamespaceAvailableConfig{
 		retryInterval: 10 * time.Millisecond,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Added support for creating namespace with on-demand capacity mode
- Block setting namespace capacity to null once configured

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace capacity semantics by allowing `capacity` during create (with validation) and adding plan/update-time guards that can cause previously-accepted config changes to error.
> 
> **Overview**
> Enables specifying `capacity` during `temporalcloud_namespace` creation **only** for `mode = "on_demand"`, and returns a clear error if `provisioned` is attempted at create time.
> 
> Adds validation in `ModifyPlan` and `Update` to **block removing** the `capacity` block once it has been set in state, guiding users to explicitly revert via `capacity { mode = "on_demand" }` instead.
> 
> Updates acceptance tests by disabling a namespace auth transition test (now TODO) and adding new coverage for the create-time capacity mode restriction and the “capacity cannot be removed once set” error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0d93222f868d3180dd09fa552c6220c152b6a22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->