### PR TITLE
Add support for custom error message and link in codec server for namespaces. Closes #408

### DIFF
--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -81,6 +81,8 @@ Read-Only:
 
 Read-Only:
 
+- `custom_error_link` (String) A link displayed alongside the custom error message for the codec server.
+- `custom_error_message` (String) A custom error message to display when the codec server returns an error.
 - `endpoint` (String) The endpoint of the codec server.
 - `include_cross_origin_credentials` (Boolean) If true, Temporal Cloud will include cross-origin credentials in requests to the codec server.
 - `pass_access_token` (Boolean) If true, Temporal Cloud will pass the access token to the codec server upon each request.

--- a/docs/data-sources/namespaces.md
+++ b/docs/data-sources/namespaces.md
@@ -84,6 +84,8 @@ Read-Only:
 
 Read-Only:
 
+- `custom_error_link` (String) A link displayed alongside the custom error message for the codec server.
+- `custom_error_message` (String) A custom error message to display when the codec server returns an error.
 - `endpoint` (String) The endpoint of the codec server.
 - `include_cross_origin_credentials` (Boolean) If true, Temporal Cloud will include cross-origin credentials in requests to the codec server.
 - `pass_access_token` (Boolean) If true, Temporal Cloud will pass the access token to the codec server upon each request.

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -196,6 +196,8 @@ Required:
 
 Optional:
 
+- `custom_error_link` (String) A link displayed alongside the custom error message for the codec server.
+- `custom_error_message` (String) A custom error message to display when the codec server returns an error.
 - `include_cross_origin_credentials` (Boolean) If true, Temporal Cloud will include cross-origin credentials in requests to the codec server.
 - `pass_access_token` (Boolean) If true, Temporal Cloud will pass the access token to the codec server upon each request.
 

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -104,6 +104,8 @@ type (
 		Endpoint                      types.String `tfsdk:"endpoint"`
 		PassAccessToken               types.Bool   `tfsdk:"pass_access_token"`
 		IncludeCrossOriginCredentials types.Bool   `tfsdk:"include_cross_origin_credentials"`
+		CustomErrorMessage            types.String `tfsdk:"custom_error_message"`
+		CustomErrorLink               types.String `tfsdk:"custom_error_link"`
 	}
 
 	endpointsModel struct {
@@ -135,6 +137,8 @@ var (
 		"endpoint":                         types.StringType,
 		"pass_access_token":                types.BoolType,
 		"include_cross_origin_credentials": types.BoolType,
+		"custom_error_message":             types.StringType,
+		"custom_error_link":                types.StringType,
 	}
 
 	lifecycleAttrs = map[string]attr.Type{
@@ -278,6 +282,14 @@ func (r *namespaceResource) Schema(ctx context.Context, _ resource.SchemaRequest
 						Description: "If true, Temporal Cloud will include cross-origin credentials in requests to the codec server.",
 						Computed:    true,
 						Default:     booldefault.StaticBool(false),
+						Optional:    true,
+					},
+					"custom_error_message": schema.StringAttribute{
+						Description: "A custom error message to display when the codec server returns an error.",
+						Optional:    true,
+					},
+					"custom_error_link": schema.StringAttribute{
+						Description: "A link displayed alongside the custom error message for the codec server.",
 						Optional:    true,
 					},
 				},
@@ -960,6 +972,8 @@ func updateModelFromSpec(
 			Endpoint:                      stringOrNull(ns.GetSpec().GetCodecServer().GetEndpoint()),
 			PassAccessToken:               types.BoolValue(ns.GetSpec().GetCodecServer().GetPassAccessToken()),
 			IncludeCrossOriginCredentials: types.BoolValue(ns.GetSpec().GetCodecServer().GetIncludeCrossOriginCredentials()),
+			CustomErrorMessage:            stringOrNull(ns.GetSpec().GetCodecServer().GetCustomErrorMessage().GetDefault().GetMessage()),
+			CustomErrorLink:               stringOrNull(ns.GetSpec().GetCodecServer().GetCustomErrorMessage().GetDefault().GetLink()),
 		}
 
 		state, objectDiags := types.ObjectValueFrom(ctx, codecServerAttrs, codecServer)
@@ -1093,11 +1107,20 @@ func getCodecServerFromModel(ctx context.Context, model *namespaceResourceModel)
 	if diags.HasError() {
 		return nil, diags
 	}
-	return &namespacev1.CodecServerSpec{
+	spec := &namespacev1.CodecServerSpec{
 		Endpoint:                      codecServer.Endpoint.ValueString(),
 		PassAccessToken:               codecServer.PassAccessToken.ValueBool(),
 		IncludeCrossOriginCredentials: codecServer.IncludeCrossOriginCredentials.ValueBool(),
-	}, diags
+	}
+	if !codecServer.CustomErrorMessage.IsNull() || !codecServer.CustomErrorLink.IsNull() {
+		spec.CustomErrorMessage = &namespacev1.CodecServerSpec_CustomErrorMessage{
+			Default: &namespacev1.CodecServerSpec_CustomErrorMessage_ErrorMessage{
+				Message: codecServer.CustomErrorMessage.ValueString(),
+				Link:    codecServer.CustomErrorLink.ValueString(),
+			},
+		}
+	}
+	return spec, diags
 }
 
 func getLifecycleFromModel(ctx context.Context, model *namespaceResourceModel) (*namespacev1.LifecycleSpec, diag.Diagnostics) {

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"go.temporal.io/cloud-sdk/api/namespace/v1"
@@ -316,6 +317,8 @@ func TestAccNamespaceWithCodecServer(t *testing.T) {
 			Endpoint                      string
 			PassAccessToken               bool
 			IncludeCrossOriginCredentials bool
+			CustomErrorMessage            string
+			CustomErrorLink               string
 		}
 
 		configArgs struct {
@@ -371,6 +374,12 @@ PEM
     endpoint                         = "{{ .Endpoint }}"
     pass_access_token                = {{ .PassAccessToken }}
     include_cross_origin_credentials = {{ .IncludeCrossOriginCredentials }}
+    {{ if .CustomErrorMessage }}
+    custom_error_message             = "{{ .CustomErrorMessage }}"
+    {{ end }}
+    {{ if .CustomErrorLink }}
+    custom_error_link                = "{{ .CustomErrorLink }}"
+    {{ end }}
   }
   {{ end }}
 }`))
@@ -438,6 +447,45 @@ PEM
 					}
 					if !spec.GetCodecServer().GetIncludeCrossOriginCredentials() {
 						return errors.New("expected include_cross_origin_credentials to be true")
+					}
+					return nil
+				},
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_namespace.test",
+			},
+			{
+				Config: config(configArgs{
+					Name:          name,
+					RetentionDays: 7,
+					TLSAuth:       true,
+					CodecServer: &codecServer{
+						Endpoint:                      "https://example.com",
+						PassAccessToken:               true,
+						IncludeCrossOriginCredentials: true,
+						CustomErrorMessage:            "Contact support for codec issues",
+						CustomErrorLink:               "https://docs.example.com/troubleshooting",
+					},
+				}),
+				Check: func(s *terraform.State) error {
+					id := s.RootModule().Resources["temporalcloud_namespace.test"].Primary.Attributes["id"]
+					conn := newConnection(t)
+					ns, err := conn.GetNamespace(context.Background(), &cloudservicev1.GetNamespaceRequest{
+						Namespace: id,
+					})
+					if err != nil {
+						return fmt.Errorf("failed to get namespace: %v", err)
+					}
+
+					spec := ns.Namespace.GetSpec()
+					customErr := spec.GetCodecServer().GetCustomErrorMessage().GetDefault()
+					if customErr.GetMessage() != "Contact support for codec issues" {
+						return fmt.Errorf("unexpected custom error message: %s", customErr.GetMessage())
+					}
+					if customErr.GetLink() != "https://docs.example.com/troubleshooting" {
+						return fmt.Errorf("unexpected custom error link: %s", customErr.GetLink())
 					}
 					return nil
 				},
@@ -1249,5 +1297,236 @@ func TestWaitForNamespaceAvailableMaxAttemptsReached(t *testing.T) {
 	// Check error message indicates max attempts reached
 	if !strings.Contains(err.Error(), "not available after") && !strings.Contains(err.Error(), "attempts") {
 		t.Errorf("Expected error message to indicate max attempts reached, got: %v", err)
+	}
+}
+
+func TestUpdateModelFromSpec_CodecServerCustomErrorMessage(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name                string
+		codecServer         *namespace.CodecServerSpec
+		expectNull          bool
+		expectMessage       string
+		expectLink          string
+		expectMessageIsNull bool
+		expectLinkIsNull    bool
+	}{
+		{
+			name:       "no codec server",
+			expectNull: true,
+		},
+		{
+			name: "codec server without custom error",
+			codecServer: &namespace.CodecServerSpec{
+				Endpoint:        "https://example.com",
+				PassAccessToken: true,
+			},
+			expectMessageIsNull: true,
+			expectLinkIsNull:    true,
+		},
+		{
+			name: "codec server with custom error message and link",
+			codecServer: &namespace.CodecServerSpec{
+				Endpoint: "https://example.com",
+				CustomErrorMessage: &namespace.CodecServerSpec_CustomErrorMessage{
+					Default: &namespace.CodecServerSpec_CustomErrorMessage_ErrorMessage{
+						Message: "Contact support",
+						Link:    "https://support.example.com",
+					},
+				},
+			},
+			expectMessage: "Contact support",
+			expectLink:    "https://support.example.com",
+		},
+		{
+			name: "codec server with only custom error message",
+			codecServer: &namespace.CodecServerSpec{
+				Endpoint: "https://example.com",
+				CustomErrorMessage: &namespace.CodecServerSpec_CustomErrorMessage{
+					Default: &namespace.CodecServerSpec_CustomErrorMessage_ErrorMessage{
+						Message: "Something went wrong",
+					},
+				},
+			},
+			expectMessage:    "Something went wrong",
+			expectLinkIsNull: true,
+		},
+		{
+			name: "codec server with only custom error link",
+			codecServer: &namespace.CodecServerSpec{
+				Endpoint: "https://example.com",
+				CustomErrorMessage: &namespace.CodecServerSpec_CustomErrorMessage{
+					Default: &namespace.CodecServerSpec_CustomErrorMessage_ErrorMessage{
+						Link: "https://docs.example.com",
+					},
+				},
+			},
+			expectMessageIsNull: true,
+			expectLink:          "https://docs.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := &namespace.Namespace{
+				Namespace: "test-ns",
+				Spec: &namespace.NamespaceSpec{
+					Name:          "test-ns",
+					Regions:       []string{"aws-us-east-1"},
+					RetentionDays: 7,
+					CodecServer:   tc.codecServer,
+				},
+				Endpoints: &namespace.Endpoints{},
+			}
+
+			state := &namespaceResourceModel{}
+			diags := updateModelFromSpec(ctx, state, ns)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %+v", diags)
+			}
+
+			if tc.expectNull {
+				if !state.CodecServer.IsNull() {
+					t.Fatal("expected codec server to be null")
+				}
+				return
+			}
+
+			if state.CodecServer.IsNull() {
+				t.Fatal("expected codec server to be non-null")
+			}
+
+			attrs := state.CodecServer.Attributes()
+			msg := attrs["custom_error_message"]
+			link := attrs["custom_error_link"]
+
+			if tc.expectMessageIsNull {
+				if !msg.IsNull() {
+					t.Errorf("expected custom_error_message to be null, got %v", msg)
+				}
+			} else {
+				if msg.IsNull() {
+					t.Error("expected custom_error_message to be non-null")
+				} else if msg.String() != fmt.Sprintf("%q", tc.expectMessage) {
+					t.Errorf("expected custom_error_message %q, got %s", tc.expectMessage, msg.String())
+				}
+			}
+
+			if tc.expectLinkIsNull {
+				if !link.IsNull() {
+					t.Errorf("expected custom_error_link to be null, got %v", link)
+				}
+			} else {
+				if link.IsNull() {
+					t.Error("expected custom_error_link to be non-null")
+				} else if link.String() != fmt.Sprintf("%q", tc.expectLink) {
+					t.Errorf("expected custom_error_link %q, got %s", tc.expectLink, link.String())
+				}
+			}
+		})
+	}
+}
+
+func TestGetCodecServerFromModel_CustomErrorMessage(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		message       string
+		messageIsNull bool
+		link          string
+		linkIsNull    bool
+		expectNilCEM  bool
+		expectMessage string
+		expectLink    string
+	}{
+		{
+			name:          "both null - no custom error message",
+			messageIsNull: true,
+			linkIsNull:    true,
+			expectNilCEM:  true,
+		},
+		{
+			name:          "both set",
+			message:       "Contact support",
+			link:          "https://support.example.com",
+			expectMessage: "Contact support",
+			expectLink:    "https://support.example.com",
+		},
+		{
+			name:          "only message set",
+			message:       "Something went wrong",
+			linkIsNull:    true,
+			expectMessage: "Something went wrong",
+			expectLink:    "",
+		},
+		{
+			name:          "only link set",
+			messageIsNull: true,
+			link:          "https://docs.example.com",
+			expectMessage: "",
+			expectLink:    "https://docs.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var msgVal, linkVal types.String
+			if tc.messageIsNull {
+				msgVal = types.StringNull()
+			} else {
+				msgVal = types.StringValue(tc.message)
+			}
+			if tc.linkIsNull {
+				linkVal = types.StringNull()
+			} else {
+				linkVal = types.StringValue(tc.link)
+			}
+
+			csModel := &codecServerModel{
+				Endpoint:                      types.StringValue("https://example.com"),
+				PassAccessToken:               types.BoolValue(false),
+				IncludeCrossOriginCredentials: types.BoolValue(false),
+				CustomErrorMessage:            msgVal,
+				CustomErrorLink:               linkVal,
+			}
+
+			objVal, objDiags := types.ObjectValueFrom(ctx, codecServerAttrs, csModel)
+			if objDiags.HasError() {
+				t.Fatalf("failed to build codec server object: %+v", objDiags)
+			}
+
+			model := &namespaceResourceModel{
+				CodecServer: objVal,
+			}
+
+			spec, diags := getCodecServerFromModel(ctx, model)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %+v", diags)
+			}
+
+			if tc.expectNilCEM {
+				if spec.CustomErrorMessage != nil {
+					t.Errorf("expected nil CustomErrorMessage, got %+v", spec.CustomErrorMessage)
+				}
+				return
+			}
+
+			if spec.CustomErrorMessage == nil {
+				t.Fatal("expected non-nil CustomErrorMessage")
+			}
+			if spec.CustomErrorMessage.Default == nil {
+				t.Fatal("expected non-nil CustomErrorMessage.Default")
+			}
+			if spec.CustomErrorMessage.Default.Message != tc.expectMessage {
+				t.Errorf("expected message %q, got %q", tc.expectMessage, spec.CustomErrorMessage.Default.Message)
+			}
+			if spec.CustomErrorMessage.Default.Link != tc.expectLink {
+				t.Errorf("expected link %q, got %q", tc.expectLink, spec.CustomErrorMessage.Default.Link)
+			}
+		})
 	}
 }

--- a/internal/provider/namespaces_datasource.go
+++ b/internal/provider/namespaces_datasource.go
@@ -209,6 +209,14 @@ func namespaceDataSourceSchema(idRequired bool) map[string]schema.Attribute {
 					Computed:    true,
 					Description: "If true, Temporal Cloud will include cross-origin credentials in requests to the codec server.",
 				},
+				"custom_error_message": schema.StringAttribute{
+					Computed:    true,
+					Description: "A custom error message to display when the codec server returns an error.",
+				},
+				"custom_error_link": schema.StringAttribute{
+					Computed:    true,
+					Description: "A link displayed alongside the custom error message for the codec server.",
+				},
 			},
 		},
 		"endpoints": schema.SingleNestedAttribute{
@@ -435,6 +443,8 @@ func namespaceToNamespaceDataModel(ctx context.Context, ns *namespacev1.Namespac
 			Endpoint:                      stringOrNull(ns.GetSpec().GetCodecServer().GetEndpoint()),
 			PassAccessToken:               types.BoolValue(ns.GetSpec().GetCodecServer().GetPassAccessToken()),
 			IncludeCrossOriginCredentials: types.BoolValue(ns.GetSpec().GetCodecServer().GetIncludeCrossOriginCredentials()),
+			CustomErrorMessage:            stringOrNull(ns.GetSpec().GetCodecServer().GetCustomErrorMessage().GetDefault().GetMessage()),
+			CustomErrorLink:               stringOrNull(ns.GetSpec().GetCodecServer().GetCustomErrorMessage().GetDefault().GetLink()),
 		}
 		s, objectDiags := types.ObjectValueFrom(ctx, codecServerAttrs, csModel)
 		diags.Append(objectDiags...)


### PR DESCRIPTION
## What was changed
Add optional fields to codec_server for custom error message and link

## Why?
Spurred by customer ticket; Match functionality with UI.

## Checklist


1. Closes #408 

2. How was this tested:
Added unit tests, and ran against existing tests and CI

3. Any docs updates needed?
Auto generated with changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it extends the `codec_server` schema and request/response mapping for namespaces, which can affect plan/state and API payloads, but changes are additive and covered by new unit/acceptance tests.
> 
> **Overview**
> Adds optional `codec_server.custom_error_message` and `codec_server.custom_error_link` to the `temporalcloud_namespace` resource and exposes the same fields as computed outputs on the `temporalcloud_namespace(s)` data sources.
> 
> Updates the namespace spec/state mapping to read/write these fields to the Cloud API (`CustomErrorMessage.Default.{Message,Link}`), and expands test coverage (acceptance + unit) to validate null vs set behaviors and import stability. Docs are regenerated to reflect the new attributes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 203e4e3ac8a1959fb7571d06ac3ffbe5c0361de3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->