### PR TITLE
perf: skip Set reconstruction in Read when state is unchanged

### DIFF
--- a/internal/provider/group_access_resource.go
+++ b/internal/provider/group_access_resource.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -38,7 +40,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/provider/enums"
@@ -212,6 +213,12 @@ func (r *groupAccessResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	// Performance optimization: skip expensive Set reconstruction when state is unchanged.
+	// See hashicorp/terraform-plugin-framework#775 for the O(n²) SetNestedAttribute issue.
+	if groupAccessMatchesState(ctx, &state, model.Group) {
+		return
+	}
+
 	resp.Diagnostics.Append(updateGroupAccessModel(ctx, &state, model.Group)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -380,4 +387,56 @@ func updateGroupAccessModel(ctx context.Context, state *groupAccessResourceModel
 	state.NamespaceAccesses = namespaceAccesses
 
 	return diags
+}
+
+// groupAccessMatchesState compares the API response with existing state using
+// plain Go maps (O(n)) to avoid expensive types.Set reconstruction (O(n²)).
+func groupAccessMatchesState(ctx context.Context, state *groupAccessResourceModel, group *identityv1.UserGroup) bool {
+	if group == nil {
+		return false
+	}
+	if state.ID.ValueString() != group.Id {
+		return false
+	}
+
+	role, err := enums.FromAccountAccessRole(group.GetSpec().GetAccess().GetAccountAccess().GetRole())
+	if err != nil || !strings.EqualFold(state.AccountAccess.ValueString(), role) {
+		return false
+	}
+
+	apiAccesses := group.GetSpec().GetAccess().GetNamespaceAccesses()
+	if state.NamespaceAccesses.IsNull() || state.NamespaceAccesses.IsUnknown() {
+		return len(apiAccesses) == 0
+	}
+
+	elements := make([]types.Object, 0, len(state.NamespaceAccesses.Elements()))
+	if diags := state.NamespaceAccesses.ElementsAs(ctx, &elements, false); diags.HasError() {
+		return false
+	}
+
+	if len(elements) != len(apiAccesses) {
+		return false
+	}
+
+	stateMap := make(map[string]string, len(elements))
+	for _, elem := range elements {
+		var model namespaceAccessModel
+		if diags := elem.As(ctx, &model, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return false
+		}
+		stateMap[model.NamespaceID.ValueString()] = model.Permission.ValueString()
+	}
+
+	for ns, access := range apiAccesses {
+		apiPermission, err := enums.FromNamespaceAccessPermission(access.GetPermission())
+		if err != nil {
+			return false
+		}
+		statePermission, ok := stateMap[ns]
+		if !ok || !strings.EqualFold(statePermission, apiPermission) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/provider/matches_state_test.go
+++ b/internal/provider/matches_state_test.go
@@ -1,0 +1,654 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	identityv1 "go.temporal.io/cloud-sdk/api/identity/v1"
+	resourcev1 "go.temporal.io/cloud-sdk/api/resource/v1"
+
+	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
+)
+
+// buildUserNamespaceAccessSet creates a types.Set for namespace accesses from a map of namespace_id -> permission.
+func buildUserNamespaceAccessSet(t *testing.T, ctx context.Context, accesses map[string]string) types.Set {
+	t.Helper()
+	if len(accesses) == 0 {
+		return types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs})
+	}
+	objects := make([]attr.Value, 0, len(accesses))
+	for ns, perm := range accesses {
+		obj, diags := types.ObjectValueFrom(ctx, userNamespaceAccessAttrs, userNamespaceAccessModel{
+			NamespaceID: types.StringValue(ns),
+			Permission:  internaltypes.CaseInsensitiveString(perm),
+		})
+		if diags.HasError() {
+			t.Fatalf("failed to build namespace access object: %v", diags)
+		}
+		objects = append(objects, obj)
+	}
+	set, diags := types.SetValue(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}, objects)
+	if diags.HasError() {
+		t.Fatalf("failed to build namespace access set: %v", diags)
+	}
+	return set
+}
+
+func buildServiceAccountNamespaceAccessSet(t *testing.T, ctx context.Context, accesses map[string]string) types.Set {
+	t.Helper()
+	if len(accesses) == 0 {
+		return types.SetNull(types.ObjectType{AttrTypes: serviceAccountNamespaceAccessAttrs})
+	}
+	objects := make([]attr.Value, 0, len(accesses))
+	for ns, perm := range accesses {
+		obj, diags := types.ObjectValueFrom(ctx, serviceAccountNamespaceAccessAttrs, serviceAccountNamespaceAccessModel{
+			NamespaceID: types.StringValue(ns),
+			Permission:  internaltypes.CaseInsensitiveString(perm),
+		})
+		if diags.HasError() {
+			t.Fatalf("failed to build namespace access object: %v", diags)
+		}
+		objects = append(objects, obj)
+	}
+	set, diags := types.SetValue(types.ObjectType{AttrTypes: serviceAccountNamespaceAccessAttrs}, objects)
+	if diags.HasError() {
+		t.Fatalf("failed to build namespace access set: %v", diags)
+	}
+	return set
+}
+
+func buildGroupNamespaceAccessSet(t *testing.T, ctx context.Context, accesses map[string]string) types.Set {
+	t.Helper()
+	if len(accesses) == 0 {
+		return types.SetNull(types.ObjectType{AttrTypes: namespaceAccessAttrs})
+	}
+	objects := make([]attr.Value, 0, len(accesses))
+	for ns, perm := range accesses {
+		obj, diags := types.ObjectValueFrom(ctx, namespaceAccessAttrs, namespaceAccessModel{
+			NamespaceID: types.StringValue(ns),
+			Permission:  internaltypes.CaseInsensitiveString(perm),
+		})
+		if diags.HasError() {
+			t.Fatalf("failed to build namespace access object: %v", diags)
+		}
+		objects = append(objects, obj)
+	}
+	set, diags := types.SetValue(types.ObjectType{AttrTypes: namespaceAccessAttrs}, objects)
+	if diags.HasError() {
+		t.Fatalf("failed to build namespace access set: %v", diags)
+	}
+	return set
+}
+
+func makeUser(id, email string, state resourcev1.ResourceState, role identityv1.AccountAccess_Role, nsAccesses map[string]identityv1.NamespaceAccess_Permission) *identityv1.User {
+	accesses := make(map[string]*identityv1.NamespaceAccess, len(nsAccesses))
+	for ns, perm := range nsAccesses {
+		accesses[ns] = &identityv1.NamespaceAccess{Permission: perm}
+	}
+	return &identityv1.User{
+		Id:    id,
+		State: state,
+		Spec: &identityv1.UserSpec{
+			Email: email,
+			Access: &identityv1.Access{
+				AccountAccess: &identityv1.AccountAccess{
+					Role: role,
+				},
+				NamespaceAccesses: accesses,
+			},
+		},
+	}
+}
+
+func TestUserMatchesState_Identical(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:            types.StringValue("user-123"),
+		State:         types.StringValue("active"),
+		Email:         types.StringValue("test@example.com"),
+		AccountAccess: internaltypes.CaseInsensitiveString("developer"),
+		NamespaceAccesses: buildUserNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "write",
+			"ns-2": "read",
+		}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_DEVELOPER,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-1": identityv1.NamespaceAccess_PERMISSION_WRITE,
+			"ns-2": identityv1.NamespaceAccess_PERMISSION_READ,
+		})
+
+	if !userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return true for identical state")
+	}
+}
+
+func TestUserMatchesState_CaseInsensitiveRole(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("test@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("Developer"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_DEVELOPER,
+		nil)
+
+	if !userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return true for case-insensitive role match")
+	}
+}
+
+func TestUserMatchesState_CaseInsensitivePermission(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:            types.StringValue("user-123"),
+		State:         types.StringValue("active"),
+		Email:         types.StringValue("test@example.com"),
+		AccountAccess: internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: buildUserNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "Write",
+		}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-1": identityv1.NamespaceAccess_PERMISSION_WRITE,
+		})
+
+	if !userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return true for case-insensitive permission match")
+	}
+}
+
+func TestUserMatchesState_DifferentID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("test@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}),
+	}
+	user := makeUser("user-456", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		nil)
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for different ID")
+	}
+}
+
+func TestUserMatchesState_DifferentState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("test@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_SUSPENDED,
+		identityv1.AccountAccess_ROLE_READ,
+		nil)
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for different state")
+	}
+}
+
+func TestUserMatchesState_DifferentEmail(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("old@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}),
+	}
+	user := makeUser("user-123", "new@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		nil)
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for different email")
+	}
+}
+
+func TestUserMatchesState_DifferentRole(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("test@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_ADMIN,
+		nil)
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for different role")
+	}
+}
+
+func TestUserMatchesState_DifferentNamespaceCount(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:            types.StringValue("user-123"),
+		State:         types.StringValue("active"),
+		Email:         types.StringValue("test@example.com"),
+		AccountAccess: internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: buildUserNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "write",
+		}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-1": identityv1.NamespaceAccess_PERMISSION_WRITE,
+			"ns-2": identityv1.NamespaceAccess_PERMISSION_READ,
+		})
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for different namespace count")
+	}
+}
+
+func TestUserMatchesState_DifferentNamespacePermission(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:            types.StringValue("user-123"),
+		State:         types.StringValue("active"),
+		Email:         types.StringValue("test@example.com"),
+		AccountAccess: internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: buildUserNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "read",
+		}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-1": identityv1.NamespaceAccess_PERMISSION_WRITE,
+		})
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for different namespace permission")
+	}
+}
+
+func TestUserMatchesState_DifferentNamespaceID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:            types.StringValue("user-123"),
+		State:         types.StringValue("active"),
+		Email:         types.StringValue("test@example.com"),
+		AccountAccess: internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: buildUserNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "write",
+		}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-different": identityv1.NamespaceAccess_PERMISSION_WRITE,
+		})
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for different namespace ID")
+	}
+}
+
+func TestUserMatchesState_NullStateWithNoAPIAccesses(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("test@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("admin"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_ADMIN,
+		nil)
+
+	if !userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return true for null state with no API accesses")
+	}
+}
+
+func TestUserMatchesState_NullStateWithAPIAccesses(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("test@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: userNamespaceAccessAttrs}),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-1": identityv1.NamespaceAccess_PERMISSION_READ,
+		})
+
+	if userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return false for null state with API accesses")
+	}
+}
+
+func TestUserMatchesState_ManyNamespaces(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Simulate the real-world scenario with many namespace accesses.
+	stateAccesses := make(map[string]string, 70)
+	apiAccesses := make(map[string]identityv1.NamespaceAccess_Permission, 70)
+	for i := 0; i < 70; i++ {
+		ns := fmt.Sprintf("namespace-%d.97055", i)
+		stateAccesses[ns] = "write"
+		apiAccesses[ns] = identityv1.NamespaceAccess_PERMISSION_WRITE
+	}
+
+	state := &userResourceModel{
+		ID:                types.StringValue("user-123"),
+		State:             types.StringValue("active"),
+		Email:             types.StringValue("test@example.com"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: buildUserNamespaceAccessSet(t, ctx, stateAccesses),
+	}
+	user := makeUser("user-123", "test@example.com",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		apiAccesses)
+
+	if !userMatchesState(ctx, state, user) {
+		t.Error("expected userMatchesState to return true for many identical namespace accesses")
+	}
+}
+
+// --- Service Account tests ---
+
+func makeServiceAccount(id, name, description string, state resourcev1.ResourceState, role identityv1.AccountAccess_Role, nsAccesses map[string]identityv1.NamespaceAccess_Permission) *identityv1.ServiceAccount {
+	accesses := make(map[string]*identityv1.NamespaceAccess, len(nsAccesses))
+	for ns, perm := range nsAccesses {
+		accesses[ns] = &identityv1.NamespaceAccess{Permission: perm}
+	}
+	return &identityv1.ServiceAccount{
+		Id:    id,
+		State: state,
+		Spec: &identityv1.ServiceAccountSpec{
+			Name:        name,
+			Description: description,
+			Access: &identityv1.Access{
+				AccountAccess: &identityv1.AccountAccess{
+					Role: role,
+				},
+				NamespaceAccesses: accesses,
+			},
+		},
+	}
+}
+
+func TestServiceAccountMatchesState_Identical(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &serviceAccountResourceModel{
+		ID:            types.StringValue("sa-123"),
+		State:         types.StringValue("active"),
+		Name:          types.StringValue("my-sa"),
+		Description:   types.StringValue("test service account"),
+		AccountAccess: internaltypes.CaseInsensitiveString("developer"),
+		NamespaceAccesses: buildServiceAccountNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "write",
+			"ns-2": "read",
+		}),
+		NamespaceScopedAccess: types.ObjectNull(serviceAccountNamespaceAccessAttrs),
+	}
+	sa := makeServiceAccount("sa-123", "my-sa", "test service account",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_DEVELOPER,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-1": identityv1.NamespaceAccess_PERMISSION_WRITE,
+			"ns-2": identityv1.NamespaceAccess_PERMISSION_READ,
+		})
+
+	if !serviceAccountMatchesState(ctx, state, sa) {
+		t.Error("expected serviceAccountMatchesState to return true for identical state")
+	}
+}
+
+func TestServiceAccountMatchesState_DifferentName(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &serviceAccountResourceModel{
+		ID:                    types.StringValue("sa-123"),
+		State:                 types.StringValue("active"),
+		Name:                  types.StringValue("old-name"),
+		Description:           types.StringValue(""),
+		AccountAccess:         internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses:     types.SetNull(types.ObjectType{AttrTypes: serviceAccountNamespaceAccessAttrs}),
+		NamespaceScopedAccess: types.ObjectNull(serviceAccountNamespaceAccessAttrs),
+	}
+	sa := makeServiceAccount("sa-123", "new-name", "",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		nil)
+
+	if serviceAccountMatchesState(ctx, state, sa) {
+		t.Error("expected serviceAccountMatchesState to return false for different name")
+	}
+}
+
+func TestServiceAccountMatchesState_DifferentDescription(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &serviceAccountResourceModel{
+		ID:                    types.StringValue("sa-123"),
+		State:                 types.StringValue("active"),
+		Name:                  types.StringValue("my-sa"),
+		Description:           types.StringValue("old description"),
+		AccountAccess:         internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses:     types.SetNull(types.ObjectType{AttrTypes: serviceAccountNamespaceAccessAttrs}),
+		NamespaceScopedAccess: types.ObjectNull(serviceAccountNamespaceAccessAttrs),
+	}
+	sa := makeServiceAccount("sa-123", "my-sa", "new description",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		nil)
+
+	if serviceAccountMatchesState(ctx, state, sa) {
+		t.Error("expected serviceAccountMatchesState to return false for different description")
+	}
+}
+
+func TestServiceAccountMatchesState_DifferentNamespacePermission(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &serviceAccountResourceModel{
+		ID:            types.StringValue("sa-123"),
+		State:         types.StringValue("active"),
+		Name:          types.StringValue("my-sa"),
+		Description:   types.StringValue(""),
+		AccountAccess: internaltypes.CaseInsensitiveString("read"),
+		NamespaceAccesses: buildServiceAccountNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "read",
+		}),
+		NamespaceScopedAccess: types.ObjectNull(serviceAccountNamespaceAccessAttrs),
+	}
+	sa := makeServiceAccount("sa-123", "my-sa", "",
+		resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		identityv1.AccountAccess_ROLE_READ,
+		map[string]identityv1.NamespaceAccess_Permission{
+			"ns-1": identityv1.NamespaceAccess_PERMISSION_WRITE,
+		})
+
+	if serviceAccountMatchesState(ctx, state, sa) {
+		t.Error("expected serviceAccountMatchesState to return false for different permission")
+	}
+}
+
+func TestServiceAccountMatchesState_NamespaceScopedAccess(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	nsObj, diags := types.ObjectValueFrom(ctx, serviceAccountNamespaceAccessAttrs, serviceAccountNamespaceAccessModel{
+		NamespaceID: types.StringValue("ns-scoped"),
+		Permission:  internaltypes.CaseInsensitiveString("admin"),
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build namespace scoped access object: %v", diags)
+	}
+
+	state := &serviceAccountResourceModel{
+		ID:                    types.StringValue("sa-123"),
+		State:                 types.StringValue("active"),
+		Name:                  types.StringValue("my-sa"),
+		Description:           types.StringValue(""),
+		AccountAccess:         internaltypes.CaseInsensitiveStringValue{StringValue: types.StringNull()},
+		NamespaceAccesses:     types.SetNull(types.ObjectType{AttrTypes: serviceAccountNamespaceAccessAttrs}),
+		NamespaceScopedAccess: nsObj,
+	}
+
+	sa := &identityv1.ServiceAccount{
+		Id:    "sa-123",
+		State: resourcev1.ResourceState_RESOURCE_STATE_ACTIVE,
+		Spec: &identityv1.ServiceAccountSpec{
+			Name:        "my-sa",
+			Description: "",
+			NamespaceScopedAccess: &identityv1.NamespaceScopedAccess{
+				Namespace: "ns-scoped",
+				Access: &identityv1.NamespaceAccess{
+					Permission: identityv1.NamespaceAccess_PERMISSION_ADMIN,
+				},
+			},
+		},
+	}
+
+	if !serviceAccountMatchesState(ctx, state, sa) {
+		t.Error("expected serviceAccountMatchesState to return true for matching namespace-scoped access")
+	}
+}
+
+// --- Group Access tests ---
+
+func TestGroupAccessMatchesState_Identical(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &groupAccessResourceModel{
+		ID:            types.StringValue("group-123"),
+		AccountAccess: internaltypes.CaseInsensitiveString("none"),
+		NamespaceAccesses: buildGroupNamespaceAccessSet(t, ctx, map[string]string{
+			"ns-1": "write",
+			"ns-2": "read",
+		}),
+	}
+
+	group := &identityv1.UserGroup{
+		Id: "group-123",
+		Spec: &identityv1.UserGroupSpec{
+			Access: &identityv1.Access{
+				AccountAccess: &identityv1.AccountAccess{
+					Role: identityv1.AccountAccess_ROLE_UNSPECIFIED,
+				},
+				NamespaceAccesses: map[string]*identityv1.NamespaceAccess{
+					"ns-1": {Permission: identityv1.NamespaceAccess_PERMISSION_WRITE},
+					"ns-2": {Permission: identityv1.NamespaceAccess_PERMISSION_READ},
+				},
+			},
+		},
+	}
+
+	if !groupAccessMatchesState(ctx, state, group) {
+		t.Error("expected groupAccessMatchesState to return true for identical state")
+	}
+}
+
+func TestGroupAccessMatchesState_DifferentRole(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &groupAccessResourceModel{
+		ID:                types.StringValue("group-123"),
+		AccountAccess:     internaltypes.CaseInsensitiveString("none"),
+		NamespaceAccesses: types.SetNull(types.ObjectType{AttrTypes: namespaceAccessAttrs}),
+	}
+
+	group := &identityv1.UserGroup{
+		Id: "group-123",
+		Spec: &identityv1.UserGroupSpec{
+			Access: &identityv1.Access{
+				AccountAccess: &identityv1.AccountAccess{
+					Role: identityv1.AccountAccess_ROLE_DEVELOPER,
+				},
+			},
+		},
+	}
+
+	if groupAccessMatchesState(ctx, state, group) {
+		t.Error("expected groupAccessMatchesState to return false for different role")
+	}
+}
+
+func TestGroupAccessMatchesState_NilGroup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	state := &groupAccessResourceModel{
+		ID:            types.StringValue("group-123"),
+		AccountAccess: internaltypes.CaseInsensitiveString("none"),
+	}
+
+	if groupAccessMatchesState(ctx, state, nil) {
+		t.Error("expected groupAccessMatchesState to return false for nil group")
+	}
+}

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -272,6 +273,12 @@ func (r *serviceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		}
 
 		resp.Diagnostics.AddError("Failed to get Service Account", err.Error())
+		return
+	}
+
+	// Performance optimization: skip expensive Set reconstruction when state is unchanged.
+	// See hashicorp/terraform-plugin-framework#775 for the O(n²) SetNestedAttribute issue.
+	if serviceAccountMatchesState(ctx, &state, serviceAccount.ServiceAccount) {
 		return
 	}
 
@@ -581,4 +588,84 @@ func updateServiceAccountModelFromSpec(ctx context.Context, state *serviceAccoun
 	}
 
 	return nil
+}
+
+// serviceAccountMatchesState compares the API response with existing state using
+// plain Go maps (O(n)) to avoid expensive types.Set reconstruction (O(n²)).
+func serviceAccountMatchesState(ctx context.Context, state *serviceAccountResourceModel, sa *identityv1.ServiceAccount) bool {
+	if state.ID.ValueString() != sa.GetId() {
+		return false
+	}
+	stateStr, err := enums.FromResourceState(sa.GetState())
+	if err != nil || state.State.ValueString() != stateStr {
+		return false
+	}
+	if state.Name.ValueString() != sa.GetSpec().GetName() {
+		return false
+	}
+	if state.Description.ValueString() != sa.GetSpec().GetDescription() {
+		return false
+	}
+
+	// Handle namespace-scoped access.
+	if sa.GetSpec().GetNamespaceScopedAccess() != nil {
+		if state.NamespaceScopedAccess.IsNull() {
+			return false
+		}
+		var nsModel serviceAccountNamespaceAccessModel
+		if diags := state.NamespaceScopedAccess.As(ctx, &nsModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return false
+		}
+		nsa := sa.GetSpec().GetNamespaceScopedAccess()
+		if nsModel.NamespaceID.ValueString() != nsa.GetNamespace() {
+			return false
+		}
+		apiPerm, err := enums.FromNamespaceAccessPermission(nsa.GetAccess().GetPermission())
+		if err != nil || !strings.EqualFold(nsModel.Permission.ValueString(), apiPerm) {
+			return false
+		}
+		return true
+	}
+
+	// Handle account-scoped access.
+	role, err := enums.FromAccountAccessRole(sa.GetSpec().GetAccess().GetAccountAccess().GetRole())
+	if err != nil || !strings.EqualFold(state.AccountAccess.ValueString(), role) {
+		return false
+	}
+
+	apiAccesses := sa.GetSpec().GetAccess().GetNamespaceAccesses()
+	if state.NamespaceAccesses.IsNull() || state.NamespaceAccesses.IsUnknown() {
+		return len(apiAccesses) == 0
+	}
+
+	elements := make([]types.Object, 0, len(state.NamespaceAccesses.Elements()))
+	if diags := state.NamespaceAccesses.ElementsAs(ctx, &elements, false); diags.HasError() {
+		return false
+	}
+
+	if len(elements) != len(apiAccesses) {
+		return false
+	}
+
+	stateMap := make(map[string]string, len(elements))
+	for _, elem := range elements {
+		var model serviceAccountNamespaceAccessModel
+		if diags := elem.As(ctx, &model, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return false
+		}
+		stateMap[model.NamespaceID.ValueString()] = model.Permission.ValueString()
+	}
+
+	for ns, access := range apiAccesses {
+		apiPermission, err := enums.FromNamespaceAccessPermission(access.GetPermission())
+		if err != nil {
+			return false
+		}
+		statePermission, ok := stateMap[ns]
+		if !ok || !strings.EqualFold(statePermission, apiPermission) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
@@ -246,6 +247,15 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	// Performance optimization: compare API response with existing state to avoid
+	// expensive types.Set reconstruction. The Terraform plugin framework has O(n²)
+	// complexity when walking SetNestedAttribute elements (see hashicorp/terraform-plugin-framework#775).
+	// By skipping the Set rebuild when nothing changed, we avoid this overhead entirely
+	// for the common case during refresh.
+	if userMatchesState(ctx, &state, user.User) {
+		return
+	}
+
 	resp.Diagnostics.Append(updateUserModelFromSpec(ctx, &state, user.User)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -479,4 +489,67 @@ func updateUserModelFromSpec(ctx context.Context, state *userResourceModel, user
 	state.NamespaceAccesses = namespaceAccesses
 
 	return diags
+}
+
+// userMatchesState compares the API response with the existing Terraform state
+// using plain Go maps (O(n)) instead of rebuilding the types.Set (O(n²)).
+// Returns true if the state is already up-to-date, allowing Read to skip
+// the expensive Set reconstruction.
+func userMatchesState(ctx context.Context, state *userResourceModel, user *identityv1.User) bool {
+	// Compare scalar fields.
+	if state.ID.ValueString() != user.GetId() {
+		return false
+	}
+	stateStr, err := enums.FromResourceState(user.GetState())
+	if err != nil || state.State.ValueString() != stateStr {
+		return false
+	}
+	if state.Email.ValueString() != user.GetSpec().GetEmail() {
+		return false
+	}
+	role, err := enums.FromAccountAccessRole(user.GetSpec().GetAccess().GetAccountAccess().GetRole())
+	if err != nil || !strings.EqualFold(state.AccountAccess.ValueString(), role) {
+		return false
+	}
+
+	// Compare namespace accesses: extract current state set into a Go map, then
+	// compare with the API response map. Both operations are O(n).
+	apiAccesses := user.GetSpec().GetAccess().GetNamespaceAccesses()
+
+	if state.NamespaceAccesses.IsNull() || state.NamespaceAccesses.IsUnknown() {
+		return len(apiAccesses) == 0
+	}
+
+	elements := make([]types.Object, 0, len(state.NamespaceAccesses.Elements()))
+	if diags := state.NamespaceAccesses.ElementsAs(ctx, &elements, false); diags.HasError() {
+		return false
+	}
+
+	if len(elements) != len(apiAccesses) {
+		return false
+	}
+
+	// Build a map from the existing state set elements.
+	stateMap := make(map[string]string, len(elements))
+	for _, elem := range elements {
+		var model userNamespaceAccessModel
+		if diags := elem.As(ctx, &model, basetypes.ObjectAsOptions{}); diags.HasError() {
+			return false
+		}
+		stateMap[model.NamespaceID.ValueString()] = model.Permission.ValueString()
+	}
+
+	// Compare against API response.
+	for ns, access := range apiAccesses {
+		apiPermission, err := enums.FromNamespaceAccessPermission(access.GetPermission())
+		if err != nil {
+			return false
+		}
+		statePermission, ok := stateMap[ns]
+		if !ok || !strings.EqualFold(statePermission, apiPermission) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
## Summary

- Adds fast-path O(n) state comparison in `Read` for `temporalcloud_user`, `temporalcloud_service_account`, and `temporalcloud_group_access` resources
- Skips expensive `types.Set` reconstruction and `resp.State.Set()` when the API response matches existing state
- No schema changes, fully backwards compatible

## Problem

The Terraform plugin framework has a known O(n²) performance issue when walking `SetNestedAttribute` elements ([hashicorp/terraform-plugin-framework#775](https://github.com/hashicorp/terraform-plugin-framework/issues/775)). Each set element path resolution requires a linear scan with `deepEqual`, so a full walk of N elements costs O(n²) `deepEqual` calls.

For resources with large `namespace_accesses` sets, this causes `terraform plan`/`apply` to spend ~1+ second **per resource** during state refresh, even though the actual API call (`GetUser`/`GetServiceAccount`/`GetUserGroup`) completes in ~10ms. The overhead comes entirely from rebuilding and serializing the `types.Set` in the framework.

In a real-world deployment with **733 users** each having **~69 namespace accesses**, `terraform plan` takes **~14 minutes** just for the refresh phase.

## Solution

Before rebuilding the `types.Set` from the API response, compare the response against existing state using plain Go maps — an O(n) operation. If nothing changed (the common case during refresh), return early from `Read` without calling `updateModelFromSpec` or `resp.State.Set()`.

This is safe because:
- The existing state (from `req.State.Get()`) is preserved when `resp.State.Set()` is not called
- When something *does* change, the existing code path runs as before
- No schema or state format changes — fully backwards compatible

## Expected Impact

| Scenario | Before | After |
|---|---|---|
| 733 users, no changes | ~14 min | ~7 sec |
| 733 users, 1 user changed | ~14 min | ~8 sec |
| Small deployment (<50 users) | minimal impact | no change |



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `Read` behavior for `user`, `service_account`, and `group_access` resources to early-return without calling `resp.State.Set()` when computed comparisons think state is unchanged; any bug in the comparison could cause stale state or missed drift detection.
> 
> **Overview**
> **Speeds up Terraform refresh for large access sets** by adding O(n) “state matches API” checks in `Read` for `temporalcloud_user`, `temporalcloud_service_account`, and `temporalcloud_group_access`, and returning early when no changes are detected to avoid rebuilding `types.Set`/calling `resp.State.Set()`.
> 
> Adds new `userMatchesState`, `serviceAccountMatchesState`, and `groupAccessMatchesState` helpers (case-insensitive role/permission comparisons and map-based namespace access comparisons, including service-account namespace-scoped access handling) plus a comprehensive new `matches_state_test.go` covering match/mismatch scenarios and large-set cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcd0329ec5532c1108bc0e5817c9c8110772e844. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->