### PR TITLE
Connectivity rule stable IPs

### DIFF
--- a/docs/data-sources/connectivity_rule.md
+++ b/docs/data-sources/connectivity_rule.md
@@ -24,6 +24,7 @@ Fetches details about a connectivity rule.
 - `connection_id` (String) The ID of the connection to the connectivity rule.
 - `connectivity_type` (String) The type of connectivity.
 - `created_at` (String) The time the connectivity rule was created.
+- `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule are reachable via a predictable set of public IPs. Only set for public connectivity rules.
 - `gcp_project_id` (String) The GCP project ID of the connectivity rule.
 - `region` (String) The region of the connectivity rule.
 - `state` (String) The current state of the connectivity rule.

--- a/docs/resources/connectivity_rule.md
+++ b/docs/resources/connectivity_rule.md
@@ -30,6 +30,12 @@ resource "temporalcloud_connectivity_rule" "public_rule" {
   connectivity_type = "public"
 }
 
+// Create Public Connectivity Rule with stable IPs enabled
+resource "temporalcloud_connectivity_rule" "public_rule_stable_ips" {
+  connectivity_type = "public"
+  enable_stable_ips = true
+}
+
 // Create Private Connectivity Rule for AWS
 resource "temporalcloud_connectivity_rule" "private_aws" {
   connectivity_type = "private"
@@ -67,6 +73,7 @@ resource "temporalcloud_namespace" "ns-with-cr" {
 ### Optional
 
 - `connection_id` (String) The connection ID of the private connection.
+- `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.
 - `gcp_project_id` (String) The GCP project ID. Required when cloud_provider is 'gcp'.
 - `region` (String) The region of the connection. Example: 'aws-us-west-2'.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/examples/resources/temporalcloud_connectivity_rule/resource.tf
+++ b/examples/resources/temporalcloud_connectivity_rule/resource.tf
@@ -15,6 +15,12 @@ resource "temporalcloud_connectivity_rule" "public_rule" {
   connectivity_type = "public"
 }
 
+// Create Public Connectivity Rule with stable IPs enabled
+resource "temporalcloud_connectivity_rule" "public_rule_stable_ips" {
+  connectivity_type = "public"
+  enable_stable_ips = true
+}
+
 // Create Private Connectivity Rule for AWS
 resource "temporalcloud_connectivity_rule" "private_aws" {
   connectivity_type = "private"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	github.com/jpillora/maplock v0.0.0-20160420012925-5c725ac6e22a
 	go.temporal.io/api v1.53.0
-	go.temporal.io/cloud-sdk v0.11.0
+	go.temporal.io/cloud-sdk v0.13.0
 	go.temporal.io/sdk v1.36.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.9

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.temporal.io/api v1.53.0 h1:6vAFpXaC584AIELa6pONV56MTpkm4Ha7gPWL2acNAjo=
 go.temporal.io/api v1.53.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/cloud-sdk v0.11.0 h1:9hP4xapYy24o8xyyP+eICa7xJMOE6rq1pG7vfPPtU7g=
-go.temporal.io/cloud-sdk v0.11.0/go.mod h1:W2O9t9tvo3Q/LhGgYdj8JijWbN5C84os+cz/BadIHYI=
+go.temporal.io/cloud-sdk v0.13.0 h1:Yhh6TEQG7xZgn8/A7C9WcxM+LS08qXlITRicuo2zGOA=
+go.temporal.io/cloud-sdk v0.13.0/go.mod h1:W2O9t9tvo3Q/LhGgYdj8JijWbN5C84os+cz/BadIHYI=
 go.temporal.io/sdk v1.36.0 h1:WO9zetpybBNK7xsQth4Z+3Zzw1zSaM9MOUGrnnUjZMo=
 go.temporal.io/sdk v1.36.0/go.mod h1:8BxGRF0LcQlfQrLLGkgVajbsKUp/PY7280XTdcKc18Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/provider/connectivity_rule_datasource.go
+++ b/internal/provider/connectivity_rule_datasource.go
@@ -35,6 +35,7 @@ type (
 		ConnectionID     types.String `tfsdk:"connection_id"`
 		Region           types.String `tfsdk:"region"`
 		GcpProjectID     types.String `tfsdk:"gcp_project_id"`
+		EnableStableIps  types.Bool   `tfsdk:"enable_stable_ips"`
 
 		State     types.String `tfsdk:"state"`
 		CreatedAt types.String `tfsdk:"created_at"`
@@ -70,6 +71,10 @@ func connectivityRuleDataSourceSchema(idRequired bool) map[string]schema.Attribu
 		"gcp_project_id": schema.StringAttribute{
 			Computed:    true,
 			Description: "The GCP project ID of the connectivity rule.",
+		},
+		"enable_stable_ips": schema.BoolAttribute{
+			Computed:    true,
+			Description: "If true, namespaces attached to this public connectivity rule are reachable via a predictable set of public IPs. Only set for public connectivity rules.",
 		},
 		"state": schema.StringAttribute{
 			Computed:    true,
@@ -159,6 +164,7 @@ func connectivityRuleToConnectivityRuleDataModel(connectivityRule *connectivityr
 		model.ConnectivityType = types.StringValue(connectivityRuleTypePrivate)
 		model.ConnectionID = types.StringValue(connectivityRule.GetSpec().GetPrivateRule().GetConnectionId())
 		model.Region = types.StringValue(connectivityRule.GetSpec().GetPrivateRule().GetRegion())
+		model.EnableStableIps = types.BoolValue(false)
 		if connectivityRule.GetSpec().GetPrivateRule().GetGcpProjectId() != "" {
 			model.GcpProjectID = types.StringValue(connectivityRule.GetSpec().GetPrivateRule().GetGcpProjectId())
 		} else {
@@ -169,6 +175,7 @@ func connectivityRuleToConnectivityRuleDataModel(connectivityRule *connectivityr
 		model.ConnectionID = types.StringNull()
 		model.Region = types.StringNull()
 		model.GcpProjectID = types.StringNull()
+		model.EnableStableIps = types.BoolValue(connectivityRule.GetSpec().GetPublicRule().GetEnableStableIps())
 	} else {
 		diags.AddError("Invalid connectivity rule", "connectivity rule must be either public or private")
 		return nil, diags

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -42,6 +43,7 @@ type (
 		ConnectionID     types.String   `tfsdk:"connection_id"`
 		Region           types.String   `tfsdk:"region"`
 		GcpProjectID     types.String   `tfsdk:"gcp_project_id"`
+		EnableStableIps  types.Bool     `tfsdk:"enable_stable_ips"`
 		Timeouts         timeouts.Value `tfsdk:"timeouts"`
 	}
 )
@@ -110,6 +112,12 @@ func (r *connectivityRuleResource) Schema(ctx context.Context, _ resource.Schema
 			"region": schema.StringAttribute{
 				Description: "The region of the connection. Example: 'aws-us-west-2'.",
 				Optional:    true,
+			},
+			"enable_stable_ips": schema.BoolAttribute{
+				Description: "If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -278,11 +286,17 @@ func getConnectivityRuleSpecFromModel(model *connectivityRuleResourceModel) (*co
 	case connectivityRuleTypePublic:
 		return &connectivityrulev1.ConnectivityRuleSpec{
 			ConnectionType: &connectivityrulev1.ConnectivityRuleSpec_PublicRule{
-				PublicRule: &connectivityrulev1.PublicConnectivityRule{},
+				PublicRule: &connectivityrulev1.PublicConnectivityRule{
+					EnableStableIps: model.EnableStableIps.ValueBool(),
+				},
 			},
 		}, diags
 
 	case connectivityRuleTypePrivate:
+		if model.EnableStableIps.ValueBool() {
+			diags.AddError("Invalid attribute for private connectivity rule", "enable_stable_ips can only be set when connectivity_type is 'public'")
+			return nil, diags
+		}
 		if model.ConnectionID.IsNull() {
 			diags.AddError("Connection ID is required", "connection_id must be specified when connectivity_type is 'private'")
 			return nil, diags
@@ -324,6 +338,7 @@ func updateConnectivityRuleModelFromSpec(model *connectivityRuleResourceModel, c
 		model.ConnectivityType = types.StringValue(connectivityRuleTypePrivate)
 		model.ConnectionID = types.StringValue(connectivityRule.GetSpec().GetPrivateRule().GetConnectionId())
 		model.Region = types.StringValue(connectivityRule.Spec.GetPrivateRule().GetRegion())
+		model.EnableStableIps = types.BoolValue(false)
 
 		// Only set gcp_project_id if it's not empty, otherwise keep it as null
 		gcpProjectId := connectivityRule.Spec.GetPrivateRule().GetGcpProjectId()
@@ -337,6 +352,7 @@ func updateConnectivityRuleModelFromSpec(model *connectivityRuleResourceModel, c
 		model.ConnectionID = types.StringNull()
 		model.Region = types.StringNull()
 		model.GcpProjectID = types.StringNull()
+		model.EnableStableIps = types.BoolValue(connectivityRule.Spec.GetPublicRule().GetEnableStableIps())
 	} else {
 		diags.AddError("Invalid connectivity rule", "connectivity rule must be either public or private")
 		return diags

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -118,6 +119,9 @@ func (r *connectivityRuleResource) Schema(ctx context.Context, _ resource.Schema
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -298,7 +298,7 @@ func getConnectivityRuleSpecFromModel(model *connectivityRuleResourceModel) (*co
 
 	case connectivityRuleTypePrivate:
 		if model.EnableStableIps.ValueBool() {
-			diags.AddError("Invalid attribute for private connectivity rule", "enable_stable_ips can only be set when connectivity_type is 'public'")
+			diags.AddError("Invalid attribute for private connectivity rule", "enable_stable_ips can only be true when connectivity_type is 'public'")
 			return nil, diags
 		}
 		if model.ConnectionID.IsNull() {

--- a/internal/provider/connectivity_rule_resource_test.go
+++ b/internal/provider/connectivity_rule_resource_test.go
@@ -156,7 +156,7 @@ func TestAccConnectivityRuleResource_ValidationErrors(t *testing.T) {
 			{
 				Config: testAccConnectivityRuleResourceConfig_PrivateWithStableIps(),
 				// Should fail because enable_stable_ips is only valid for public rules
-				ExpectError: regexp.MustCompile("enable_stable_ips can only be set when connectivity_type is 'public'"),
+				ExpectError: regexp.MustCompile("enable_stable_ips can only be true when connectivity_type is 'public'"),
 			},
 		},
 	})

--- a/internal/provider/connectivity_rule_resource_test.go
+++ b/internal/provider/connectivity_rule_resource_test.go
@@ -62,6 +62,38 @@ func TestAccConnectivityRuleResource_Public(t *testing.T) {
 	})
 }
 
+func TestAccConnectivityRuleResource_Public_StableIps(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create a public connectivity rule with stable IPs enabled
+			{
+				Config: testAccConnectivityRuleResourceConfig_PublicStableIps(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("temporalcloud_connectivity_rule.test_public_stable_ips", "connectivity_type", "public"),
+					resource.TestCheckResourceAttr("temporalcloud_connectivity_rule.test_public_stable_ips", "enable_stable_ips", "true"),
+				),
+			},
+			// Import state testing
+			{
+				ResourceName:      "temporalcloud_connectivity_rule.test_public_stable_ips",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete the public connectivity rule
+			{
+				ResourceName:      "temporalcloud_connectivity_rule.test_public_stable_ips",
+				ImportState:       true,
+				ImportStateVerify: true,
+				Destroy:           true,
+			},
+		},
+	})
+}
+
 func TestAccConnectivityRuleResource_AWS_Private(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -121,6 +153,11 @@ func TestAccConnectivityRuleResource_ValidationErrors(t *testing.T) {
 				// Should fail at plan time due to missing required attribute
 				ExpectError: regexp.MustCompile("GCP Project ID is required"),
 			},
+			{
+				Config: testAccConnectivityRuleResourceConfig_PrivateWithStableIps(),
+				// Should fail because enable_stable_ips is only valid for public rules
+				ExpectError: regexp.MustCompile("enable_stable_ips can only be set when connectivity_type is 'public'"),
+			},
 		},
 	})
 }
@@ -134,6 +171,34 @@ provider "temporalcloud" {
 
 resource "temporalcloud_connectivity_rule" "test_public" {
   connectivity_type = "public"
+}
+`
+}
+
+func testAccConnectivityRuleResourceConfig_PublicStableIps() string {
+	return `
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_connectivity_rule" "test_public_stable_ips" {
+  connectivity_type = "public"
+  enable_stable_ips = true
+}
+`
+}
+
+func testAccConnectivityRuleResourceConfig_PrivateWithStableIps() string {
+	return `
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_connectivity_rule" "test" {
+  connectivity_type = "private"
+  connection_id     = "vpce-testconnid"
+  region            = "aws-us-west-2"
+  enable_stable_ips = true
 }
 `
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Bumps cloud-sdk to v0.13.0 and adds the `enable_stable_ips` property for the `temporalcloud_connectivity_rule` resource.

## Why?
<!-- Tell your future self why have you made these changes -->

cloud-sdk v0.13.0 added support for the `enable_stable_ips` property for public connectivity rules. Bumping the version so that we can support the feature with the terraform resource.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Acceptance tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how public connectivity is provisioned (stable IPs) and forces resource replacement when the flag changes; misconfiguration could affect namespace reachability from customer networks.
> 
> **Overview**
> Adds optional **`enable_stable_ips`** on **`temporalcloud_connectivity_rule`** (and the connectivity rule data source) so **public** rules can expose namespaces on a predictable set of public IPs. The provider bumps **`go.temporal.io/cloud-sdk`** to **v0.13.0** and wires the flag into **`PublicConnectivityRule`** on create/read; private rules reject **`enable_stable_ips = true`** at plan time and surface **`false`** when read.
> 
> The attribute defaults to **`false`**, is optional/computed on the resource, and uses **`RequiresReplace`** when toggled (connectivity rules still cannot be updated in place). Docs, examples, and acceptance tests cover the happy path and the private-rule validation error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209d9741981aa3ebbcefe0fe6cdd41899efc76e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->