### PR TITLE
Skip namespace region validation when regions are unchanged on update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,4 +86,4 @@ jobs:
       - env:
           TF_ACC: "1"
           TEMPORAL_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLOUD_API_KEY }}
-        run: go test -timeout 35m -parallel 12 -v -cover ./internal/provider/
+        run: go test -timeout 60m -parallel 12 -v -cover ./internal/provider/

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -458,28 +458,63 @@ func (r *namespaceResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 		return
 	}
 
-	regionsResp, err := r.client.CloudService().GetRegions(ctx, &cloudservicev1.GetRegionsRequest{})
+	var stateRegions []string
+	if !req.State.Raw.IsNull() {
+		var state namespaceResourceModel
+		resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		var d diag.Diagnostics
+		stateRegions, d = getRegionsFromModel(ctx, &state)
+		resp.Diagnostics.Append(d...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	getRegionsFn := func(ctx context.Context, req *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+		return r.client.CloudService().GetRegions(ctx, req)
+	}
+	resp.Diagnostics.Append(validateRegionsWithConfig(ctx, stateRegions, configuredRegions, getRegionsFn)...)
+}
+
+// validateRegionsWithConfig checks that every region in configuredRegions is valid by calling the
+// getRegionsFn.
+//
+// It skips validation when stateRegions equals configuredRegions to avoid blocking Terraform operations
+// on a namespace whose region is no longer supported for new placement.
+func validateRegionsWithConfig(
+	ctx context.Context,
+	stateRegions []string,
+	configuredRegions []string,
+	getRegionsFn func(context.Context, *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error),
+) diag.Diagnostics {
+	var diags diag.Diagnostics
+	if areRegionsEqual(stateRegions, configuredRegions) {
+		return diags
+	}
+	regionsResp, err := getRegionsFn(ctx, &cloudservicev1.GetRegionsRequest{})
 	if err != nil {
-		resp.Diagnostics.AddWarning(
+		diags.AddWarning(
 			"Unable to Validate Regions",
 			fmt.Sprintf("Failed to fetch available regions from Temporal Cloud API: %s. Region validation will be skipped.", err.Error()),
 		)
-		return
+		return diags
 	}
-
 	validRegions := make(map[string]bool, len(regionsResp.GetRegions()))
 	for _, region := range regionsResp.GetRegions() {
 		validRegions[region.GetId()] = true
 	}
-
 	for _, region := range configuredRegions {
 		if !validRegions[region] {
-			resp.Diagnostics.AddError(
+			diags.AddError(
 				"Invalid Region",
 				fmt.Sprintf("Region %q is not a valid Temporal Cloud region. Use the temporalcloud_regions data source or see https://docs.temporal.io/cloud/regions for the list of available regions.", region),
 			)
 		}
 	}
+	return diags
 }
 
 // Create creates the resource and sets the initial Terraform state.

--- a/internal/provider/namespace_resource.go
+++ b/internal/provider/namespace_resource.go
@@ -473,8 +473,8 @@ func (r *namespaceResource) ModifyPlan(ctx context.Context, req resource.ModifyP
 		}
 	}
 
-	getRegionsFn := func(ctx context.Context, req *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
-		return r.client.CloudService().GetRegions(ctx, req)
+	getRegionsFn := func(ctx context.Context, regionsReq *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+		return r.client.CloudService().GetRegions(ctx, regionsReq)
 	}
 	resp.Diagnostics.Append(validateRegionsWithConfig(ctx, stateRegions, configuredRegions, getRegionsFn)...)
 }

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	cloudservicev1 "go.temporal.io/cloud-sdk/api/cloudservice/v1"
+	regionv1 "go.temporal.io/cloud-sdk/api/region/v1"
 
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 )
@@ -212,6 +213,66 @@ resource "temporalcloud_namespace" "terraform" {
 			},
 		},
 	})
+}
+
+func TestValidateRegionsSkippedWhenUnchanged(t *testing.T) {
+	called := false
+	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+		called = true
+		return nil, errors.New("should not be called")
+	}
+
+	diags := validateRegionsWithConfig(context.Background(), []string{"aws-us-east-1"}, []string{"aws-us-east-1"}, getRegionsFn)
+
+	if called {
+		t.Error("expected GetRegions to be skipped when regions are unchanged, but it was called")
+	}
+	if diags.HasError() {
+		t.Errorf("expected no errors, got: %+v", diags)
+	}
+}
+
+func TestValidateRegionsAPIError(t *testing.T) {
+	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	diags := validateRegionsWithConfig(context.Background(), nil, []string{"aws-us-east-1"}, getRegionsFn)
+
+	if diags.HasError() {
+		t.Errorf("expected warning only (not error), got errors: %+v", diags)
+	}
+	if len(diags) == 0 {
+		t.Error("expected a warning diagnostic, got none")
+	}
+}
+
+func TestValidateRegionsValidRegion(t *testing.T) {
+	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+		return &cloudservicev1.GetRegionsResponse{
+			Regions: []*regionv1.Region{{Id: "aws-us-east-1"}},
+		}, nil
+	}
+
+	diags := validateRegionsWithConfig(context.Background(), nil, []string{"aws-us-east-1"}, getRegionsFn)
+
+	if diags.HasError() {
+		t.Errorf("expected no errors for a valid region, got: %+v", diags)
+	}
+}
+
+func TestValidateRegionsInvalidRegion(t *testing.T) {
+	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+		return &cloudservicev1.GetRegionsResponse{
+			Regions: []*regionv1.Region{{Id: "aws-us-east-1"}},
+		}, nil
+	}
+
+	diags := validateRegionsWithConfig(context.Background(), nil, []string{"aws-us-fake-99"}, getRegionsFn)
+
+	if !diags.HasError() {
+		t.Error("expected an error for an invalid region, got none")
+	}
 }
 
 func TestAccBasicNamespaceWithApiKeyAuth(t *testing.T) {

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -230,6 +230,17 @@ func TestValidateRegionsSkippedWhenUnchanged(t *testing.T) {
 	if diags.HasError() {
 		t.Errorf("expected no errors, got: %+v", diags)
 	}
+
+	// Same regions in different order — comparison is order-insensitive so validation must still be skipped.
+	called = false
+	diags = validateRegionsWithConfig(context.Background(), []string{"aws-us-east-1", "aws-us-west-2"}, []string{"aws-us-west-2", "aws-us-east-1"}, getRegionsFn)
+
+	if called {
+		t.Error("expected GetRegions to be skipped when regions are unchanged (different order), but it was called")
+	}
+	if diags.HasError() {
+		t.Errorf("expected no errors, got: %+v", diags)
+	}
 }
 
 func TestValidateRegionsAPIError(t *testing.T) {

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -215,74 +215,94 @@ resource "temporalcloud_namespace" "terraform" {
 	})
 }
 
-func TestValidateRegionsSkippedWhenUnchanged(t *testing.T) {
-	called := false
-	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
-		called = true
-		return nil, errors.New("should not be called")
+func TestValidateRegionsWithConfig(t *testing.T) {
+	t.Parallel()
+
+	availableRegions := []*regionv1.Region{{Id: "aws-us-east-1"}, {Id: "aws-us-west-2"}}
+
+	testCases := []struct {
+		name              string
+		stateRegions      []string
+		configuredRegions []string
+		getRegionsFn      func(context.Context, *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error)
+		wantAPICall       bool
+		wantError         bool
+		wantWarning       bool
+	}{
+		{
+			name:              "skip validation when regions are unchanged",
+			stateRegions:      []string{"aws-us-east-1"},
+			configuredRegions: []string{"aws-us-east-1"},
+			getRegionsFn: func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+				return nil, errors.New("should not be called")
+			},
+			wantAPICall: false,
+		},
+		{
+			name:              "skip validation when regions are unchanged (different order)",
+			stateRegions:      []string{"aws-us-east-1", "aws-us-west-2"},
+			configuredRegions: []string{"aws-us-west-2", "aws-us-east-1"},
+			getRegionsFn: func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+				return nil, errors.New("should not be called")
+			},
+			wantAPICall: false,
+		},
+		{
+			name:              "API error produces warning, not error",
+			stateRegions:      nil,
+			configuredRegions: []string{"aws-us-east-1"},
+			getRegionsFn: func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+				return nil, errors.New("connection refused")
+			},
+			wantAPICall: true,
+			wantWarning: true,
+		},
+		{
+			name:              "valid region passes validation",
+			stateRegions:      nil,
+			configuredRegions: []string{"aws-us-east-1"},
+			getRegionsFn: func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+				return &cloudservicev1.GetRegionsResponse{Regions: availableRegions}, nil
+			},
+			wantAPICall: true,
+		},
+		{
+			name:              "invalid region produces error",
+			stateRegions:      nil,
+			configuredRegions: []string{"aws-us-fake-99"},
+			getRegionsFn: func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+				return &cloudservicev1.GetRegionsResponse{Regions: availableRegions}, nil
+			},
+			wantAPICall: true,
+			wantError:   true,
+		},
 	}
 
-	diags := validateRegionsWithConfig(context.Background(), []string{"aws-us-east-1"}, []string{"aws-us-east-1"}, getRegionsFn)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	if called {
-		t.Error("expected GetRegions to be skipped when regions are unchanged, but it was called")
-	}
-	if diags.HasError() {
-		t.Errorf("expected no errors, got: %+v", diags)
-	}
+			called := false
+			wrappedFn := func(ctx context.Context, req *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
+				called = true
+				return tc.getRegionsFn(ctx, req)
+			}
 
-	// Same regions in different order — comparison is order-insensitive so validation must still be skipped.
-	called = false
-	diags = validateRegionsWithConfig(context.Background(), []string{"aws-us-east-1", "aws-us-west-2"}, []string{"aws-us-west-2", "aws-us-east-1"}, getRegionsFn)
+			diags := validateRegionsWithConfig(context.Background(), tc.stateRegions, tc.configuredRegions, wrappedFn)
 
-	if called {
-		t.Error("expected GetRegions to be skipped when regions are unchanged (different order), but it was called")
-	}
-	if diags.HasError() {
-		t.Errorf("expected no errors, got: %+v", diags)
-	}
-}
-
-func TestValidateRegionsAPIError(t *testing.T) {
-	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
-		return nil, errors.New("connection refused")
-	}
-
-	diags := validateRegionsWithConfig(context.Background(), nil, []string{"aws-us-east-1"}, getRegionsFn)
-
-	if diags.HasError() {
-		t.Errorf("expected warning only (not error), got errors: %+v", diags)
-	}
-	if len(diags) == 0 {
-		t.Error("expected a warning diagnostic, got none")
-	}
-}
-
-func TestValidateRegionsValidRegion(t *testing.T) {
-	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
-		return &cloudservicev1.GetRegionsResponse{
-			Regions: []*regionv1.Region{{Id: "aws-us-east-1"}},
-		}, nil
-	}
-
-	diags := validateRegionsWithConfig(context.Background(), nil, []string{"aws-us-east-1"}, getRegionsFn)
-
-	if diags.HasError() {
-		t.Errorf("expected no errors for a valid region, got: %+v", diags)
-	}
-}
-
-func TestValidateRegionsInvalidRegion(t *testing.T) {
-	getRegionsFn := func(_ context.Context, _ *cloudservicev1.GetRegionsRequest) (*cloudservicev1.GetRegionsResponse, error) {
-		return &cloudservicev1.GetRegionsResponse{
-			Regions: []*regionv1.Region{{Id: "aws-us-east-1"}},
-		}, nil
-	}
-
-	diags := validateRegionsWithConfig(context.Background(), nil, []string{"aws-us-fake-99"}, getRegionsFn)
-
-	if !diags.HasError() {
-		t.Error("expected an error for an invalid region, got none")
+			if called != tc.wantAPICall {
+				t.Errorf("API called = %v, want %v", called, tc.wantAPICall)
+			}
+			if tc.wantError && !diags.HasError() {
+				t.Error("expected error diagnostic, got none")
+			}
+			if !tc.wantError && diags.HasError() {
+				t.Errorf("unexpected error diagnostics: %+v", diags)
+			}
+			if tc.wantWarning && len(diags) == 0 {
+				t.Error("expected warning diagnostic, got none")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

- Skips namespace region validation when regions are unchanged on update.
- Extracts region validation from `ModifyPlan` into a testable `validateRegionsWithConfig` helper that accepts an injected `getRegionsFn`

## Why

Namespaces can be placed in regions that are no longer accepting new placement. Previously, every `terraform plan` would re-validate the region and fail, blocking all Terraform operations on those namespaces even when no region change is made.

## Test plan

Four unit tests cover all branches of `validateRegionsWithConfig`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes plan-time validation for `temporalcloud_namespace`; intentionally allows unchanged configs in regions no longer listed by the API, while still blocking invalid regions when the set changes.
> 
> **Overview**
> **Namespace plan validation** no longer calls Temporal Cloud `GetRegions` when `regions` in state and plan are the same (order-insensitive). That lets `terraform plan/apply` proceed for namespaces already placed in regions that are no longer offered for *new* placement, as long as the user is not changing regions. Region checks still run on create and when the region set changes.
> 
> Validation logic moves into **`validateRegionsWithConfig`**, with an injectable `getRegionsFn` for unit tests. CI acceptance tests get a **60m** timeout (was 35m).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c7a49e87bf76e34d99d60c2c1204b643333ddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->