### PR TITLE
VLN-1529: remediate unpinned-github-actions

### DIFF
--- a/.github/workflows/rotate-ci-apikey.yml
+++ b/.github/workflows/rotate-ci-apikey.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: rotate gcp keys
-        uses: anekkanti/github-action-rotate-temporalcloud-apikey@v0.1.0
+        uses: anekkanti/github-action-rotate-temporalcloud-apikey@7fd82d9a1548bae3b9e5f0260b3a4a2192a95402 # v0.1.0
         with:
           apikey: "${{ secrets.TEMPORAL_CLOUD_API_KEY }}"
           serviceAccountId: "${{ secrets.TEMPORAL_CLOUD_SERVICE_ACCOUNT_ID }}"


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/terraform-provider-temporalcloud</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1529">VLN-1529</a></td></tr>
</table>

## Summary

🤠 [Deputy](https://github.com/temporalio/deputy) pinned dependencies to immutable references.

- Total refs: 9
- Pinned refs: 1
- Already pinned: 8

Changed references:
- `anekkanti/github-action-rotate-temporalcloud-apikey`: `v0.1.0` -> `7fd82d9a1548bae3b9e5f0260b3a4a2192a95402 # v0.1.0`

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix