### PR TITLE
Replace region in tests

### DIFF
--- a/internal/provider/account_audit_log_sink_resource_datasource_test.go
+++ b/internal/provider/account_audit_log_sink_resource_datasource_test.go
@@ -31,7 +31,7 @@ func TestAccountAuditLogSinkResource_Schema(t *testing.T) {
 
 func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 	t.Parallel()
-	sinkRegion := "us-east-1"
+	sinkRegion := "ca-central-1"
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/group_access_resource_test.go
+++ b/internal/provider/group_access_resource_test.go
@@ -86,7 +86,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "test" {
   name = "{{ .NamespaceName }}"
-  regions = ["aws-us-east-1"]
+  regions = ["aws-ca-central-1"]
   api_key_auth = true
   retention_days = 7
 }

--- a/internal/provider/namespace_datasource_test.go
+++ b/internal/provider/namespace_datasource_test.go
@@ -2,8 +2,9 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -18,7 +19,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   api_key_auth 	 = true
   retention_days     = %d
 }
@@ -71,7 +72,7 @@ output "namespace" {
 					if !ok {
 						return fmt.Errorf("expected active_region to be a string")
 					}
-					if outputRegion != "aws-us-east-1" {
+					if outputRegion != "aws-ca-central-1" {
 						return fmt.Errorf("exptect active regon to match provided region")
 					}
 

--- a/internal/provider/namespace_export_sink_resource_test.go
+++ b/internal/provider/namespace_export_sink_resource_test.go
@@ -32,7 +32,7 @@ func TestNamespaceExportSinkResource_Schema(t *testing.T) {
 func TestAccNamespaceExportSink_S3(t *testing.T) {
 
 	namespaceName := fmt.Sprintf("tf-test-ns-export-aws-%s", randomString(8))
-	sinkRegion := "us-east-1"
+	sinkRegion := "ca-central-1"
 	namespaceRegion := fmt.Sprintf("aws-%s", sinkRegion)
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
@@ -67,7 +67,7 @@ func TestAccNamespaceExportSink_S3(t *testing.T) {
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.role_name", "test-updated-role"),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.region", sinkRegion),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.aws_account_id", "123456789013"),
-					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.kms_arn", "arn:aws:kms:us-east-1:123456789013:key/test-updated-key"),
+					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.kms_arn", "arn:aws:kms:ca-central-1:123456789013:key/test-updated-key"),
 				),
 			},
 			// Delete testing
@@ -209,7 +209,7 @@ resource "temporalcloud_namespace_export_sink" "test" {
     region         = %[4]q
     role_name      = "test-updated-role"
     aws_account_id = "123456789013"
-    kms_arn        = "arn:aws:kms:us-east-1:123456789013:key/test-updated-key"
+    kms_arn        = "arn:aws:kms:ca-central-1:123456789013:key/test-updated-key"
   }
 }
 `, namespaceName, namespaceRegion, sinkName, sinkRegion)

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -57,7 +57,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "test" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   api_key_auth       = true
   retention_days     = 7
 }`, name)
@@ -116,7 +116,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ
@@ -316,7 +316,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   api_key_auth 	 = true
   retention_days     = %d
 }`, name, retention)
@@ -353,7 +353,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "test" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ
@@ -431,7 +431,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "test" {
   name               = "{{ .Name }}-{{ .ApiKeyAuth }}"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
 
 	  {{ if .ApiKeyAuth }}
 	  api_key_auth = true
@@ -711,7 +711,7 @@ provider "temporalcloud" {
 }
 resource "temporalcloud_namespace" "test" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ
@@ -754,7 +754,7 @@ provider "temporalcloud" {
 }
 resource "temporalcloud_namespace" "test" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ
@@ -801,7 +801,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ
@@ -883,7 +883,7 @@ func TestAccNamespaceWithConnectivityRuleIds(t *testing.T) {
 	resource "temporalcloud_connectivity_rule" "%s" {
 	  connectivity_type = "private"
 	  connection_id     = "vpce-tftest%s"
-	  region            = "aws-us-east-1"
+	  region            = "aws-ca-central-1"
 	}
 	`, ruleName, ruleName)
 		}
@@ -903,7 +903,7 @@ func TestAccNamespaceWithConnectivityRuleIds(t *testing.T) {
 		
 	resource "temporalcloud_namespace" "test" {
 	  name               = "%s"
-	  regions            = ["aws-us-east-1"]
+	  regions            = ["aws-ca-central-1"]
 	  accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIBxzCCAU2gAwIBAgIRAnkbVL6hHp218oB9UlQtN7wwCgYIKoZIzj0EAwMwEjEQ
@@ -1077,7 +1077,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "capacitytest" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ
@@ -1184,7 +1184,7 @@ provider "temporalcloud" {}
 
 resource "temporalcloud_namespace" "test" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 7
   capacity = {
@@ -1212,7 +1212,7 @@ provider "temporalcloud" {}
 
 resource "temporalcloud_namespace" "test" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 7
   capacity = {
@@ -1224,7 +1224,7 @@ provider "temporalcloud" {}
 
 resource "temporalcloud_namespace" "test" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 7
 }`, name)
@@ -1253,7 +1253,7 @@ provider "temporalcloud" {}
 
 resource "temporalcloud_namespace" "fairnesstest" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 7
   fairness = {
@@ -1303,7 +1303,7 @@ provider "temporalcloud" {}
 
 resource "temporalcloud_namespace" "test" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 7
   fairness = {
@@ -1315,7 +1315,7 @@ provider "temporalcloud" {}
 
 resource "temporalcloud_namespace" "test" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 7
   fairness = {
@@ -1327,7 +1327,7 @@ provider "temporalcloud" {}
 
 resource "temporalcloud_namespace" "test" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 7
 }`, name)

--- a/internal/provider/namespace_search_attribute_resource_test.go
+++ b/internal/provider/namespace_search_attribute_resource_test.go
@@ -45,7 +45,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   retention_days     = 7
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
@@ -111,7 +111,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   retention_days     = 7
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
@@ -168,7 +168,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   retention_days     = %d
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----

--- a/internal/provider/namespace_tags_resource_test.go
+++ b/internal/provider/namespace_tags_resource_test.go
@@ -79,7 +79,7 @@ func testAccNamespaceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "temporalcloud_namespace" "test" {
   name           = "%s"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   retention_days = 1
   api_key_auth   = true
 }

--- a/internal/provider/nexus_endpoint_datasource_test.go
+++ b/internal/provider/nexus_endpoint_datasource_test.go
@@ -19,7 +19,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "target_namespace" {
   name           = "terraform-target-namespace"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 14
   timeouts {
@@ -30,7 +30,7 @@ resource "temporalcloud_namespace" "target_namespace" {
 
 resource "temporalcloud_namespace" "caller_namespace" {
   name           = "terraform-caller-namespace"
-  regions        = ["aws-us-east-1"]
+  regions        = ["aws-ca-central-1"]
   api_key_auth   = true
   retention_days = 14
   timeouts {

--- a/internal/provider/nexus_endpoint_resource_test.go
+++ b/internal/provider/nexus_endpoint_resource_test.go
@@ -79,7 +79,7 @@ resource "temporalcloud_namespace" %[1]q {
 }
 
 func testAccNexusEndpointResourceConfig(name, description, targetNamespaceName, taskQueue string, allowedNamespaces []string) string {
-	region := "aws-us-east-1"
+	region := "aws-ca-central-1"
 	retentionDays := 1
 	allowedNamespaceIDs := []string{}
 	namespacesConfig := testAccNamespaceResourceConfig("target_namespace", targetNamespaceName, region, retentionDays)

--- a/internal/provider/user_group_resource_test.go
+++ b/internal/provider/user_group_resource_test.go
@@ -95,7 +95,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "test" {
   name               = "{{ .NamespaceName }}"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   api_key_auth       = true
 
   retention_days = 7

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -105,7 +105,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "test" {
   name               = "{{ .NamespaceName }}"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIBxzCCAU2gAwIBAgIRAnkbVL6hHp218oB9UlQtN7wwCgYIKoZIzj0EAwMwEjEQ
@@ -319,7 +319,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "test" {
   name               = "{{ .NamespaceName }}"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   api_key_auth       = true
 
   retention_days = 7
@@ -327,7 +327,7 @@ resource "temporalcloud_namespace" "test" {
 
 resource "temporalcloud_namespace" "test2" {
   name               = "{{ .NamespaceName }}2"
-  regions            = ["aws-us-east-1"]
+  regions            = ["aws-ca-central-1"]
   api_key_auth       = true
 
   retention_days = 7


### PR DESCRIPTION
replacing us-east-1 with ca-central-1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture changes with no production provider logic; risk is limited to CI needing `aws-ca-central-1` availability in the test account.
> 
> **Overview**
> Acceptance test configs across the provider now default to **Canada (Central)** instead of **US East (N. Virginia)** for AWS-backed resources.
> 
> **Namespace and connectivity:** `regions` in Terraform fixtures move from `aws-us-east-1` to `aws-ca-central-1`, including namespace datasource assertions on `active_region`, connectivity rules, and shared helpers such as `testAccNamespaceConfig`.
> 
> **Sinks and AWS ARNs:** Account audit log Kinesis tests use `ca-central-1`; namespace export sink S3 tests use `ca-central-1` for sink/namespace regions and update KMS ARNs to `arn:aws:kms:ca-central-1:...`.
> 
> **Identity and Nexus:** Group access, user/group, and Nexus endpoint tests align namespace regions with `aws-ca-central-1`. `namespace_datasource_test.go` only reorders imports (no behavioral change beyond region strings).
> 
> Provider runtime code and unit tests that still reference `aws-us-east-1` (e.g. region validation mocks) are **unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e656abd5384e4181dd03d8f889b7fdc66e46527c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->