### PR TITLE
Adds azure support for namespace operations

### DIFF
--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Provisions a Temporal Cloud namespace.
   Regions available in Temporal Cloud: https://docs.temporal.io/cloud/regions.
-  Note that regions are prefixed with the cloud provider (aws-us-east-1, gcp-us-central1, azure-eastus)
+  Note that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1)
 ---
 
 # temporalcloud_namespace (Resource)
@@ -14,7 +14,7 @@ Provisions a Temporal Cloud namespace.
 
 Regions available in Temporal Cloud: https://docs.temporal.io/cloud/regions. 
 
-Note that regions are prefixed with the cloud provider (aws-us-east-1, gcp-us-central1, azure-eastus)
+Note that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1)
 
 ## Example Usage
 
@@ -148,7 +148,7 @@ resource "temporalcloud_namespace" "terraform4" {
 ### Required
 
 - `name` (String) The name of the namespace. Must be 2-64 characters, start with a letter, contain only lowercase letters, numbers, and hyphens, and not end with a hyphen.
-- `regions` (List of String) The list of regions where this namespace is available. Must be one or two regions. See https://docs.temporal.io/cloud/regions for a list of available regions and HA options. Note that regions are prefixed with the cloud provider (e.g., aws-us-east-1, gcp-us-central1, azure-eastus). If two regions are specified, the namespace will be replicated across them in a high availability (HA) configuration. Same-region, multi-region, and multi-cloud HA namespaces are supported. Please note that changing, adding, or removing regions for an existing namespace is not currently supported and the provider will throw an error. For HA namespaces the provider will ignore order changes on regions, which can happen if the namespace fails over.
+- `regions` (List of String) The list of regions where this namespace is available. Must be one or two regions. See https://docs.temporal.io/cloud/regions for a list of available regions and HA options. Note that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1). If two regions are specified, the namespace will be replicated across them in a high availability (HA) configuration. Same-region, multi-region, and multi-cloud HA namespaces are supported. Please note that changing, adding, or removing regions for an existing namespace is not currently supported and the provider will throw an error. For HA namespaces the provider will ignore order changes on regions, which can happen if the namespace fails over.
 - `retention_days` (Number) The number of days to retain workflow history. Any changes to the retention period will be applied to all new running workflows.
 
 ### Optional

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Provisions a Temporal Cloud namespace.
   Regions available in Temporal Cloud: https://docs.temporal.io/cloud/regions.
-  Note that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1)
+  Note that regions are prefixed with the cloud provider (aws-us-east-1, gcp-us-central1, azure-eastus)
 ---
 
 # temporalcloud_namespace (Resource)
@@ -14,7 +14,7 @@ Provisions a Temporal Cloud namespace.
 
 Regions available in Temporal Cloud: https://docs.temporal.io/cloud/regions. 
 
-Note that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1)
+Note that regions are prefixed with the cloud provider (aws-us-east-1, gcp-us-central1, azure-eastus)
 
 ## Example Usage
 
@@ -148,7 +148,7 @@ resource "temporalcloud_namespace" "terraform4" {
 ### Required
 
 - `name` (String) The name of the namespace. Must be 2-64 characters, start with a letter, contain only lowercase letters, numbers, and hyphens, and not end with a hyphen.
-- `regions` (List of String) The list of regions where this namespace is available. Must be one or two regions. See https://docs.temporal.io/cloud/regions for a list of available regions and HA options. Note that regions are prefixed with the cloud provider (aws-us-east-1, not us-east-1). If two regions are specified, the namespace will be replicated across them in a high availability (HA) configuration. Same-region, multi-region, and multi-cloud HA namespaces are supported. Please note that changing, adding, or removing regions for an existing namespace is not currently supported and the provider will throw an error. For HA namespaces the provider will ignore order changes on regions, which can happen if the namespace fails over.
+- `regions` (List of String) The list of regions where this namespace is available. Must be one or two regions. See https://docs.temporal.io/cloud/regions for a list of available regions and HA options. Note that regions are prefixed with the cloud provider (e.g., aws-us-east-1, gcp-us-central1, azure-eastus). If two regions are specified, the namespace will be replicated across them in a high availability (HA) configuration. Same-region, multi-region, and multi-cloud HA namespaces are supported. Please note that changing, adding, or removing regions for an existing namespace is not currently supported and the provider will throw an error. For HA namespaces the provider will ignore order changes on regions, which can happen if the namespace fails over.
 - `retention_days` (Number) The number of days to retain workflow history. Any changes to the retention period will be applied to all new running workflows.
 
 ### Optional

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	github.com/jpillora/maplock v0.0.0-20160420012925-5c725ac6e22a
 	go.temporal.io/api v1.53.0
-	go.temporal.io/cloud-sdk v0.13.0
+	go.temporal.io/cloud-sdk v0.14.1
 	go.temporal.io/sdk v1.36.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.9

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.temporal.io/api v1.53.0 h1:6vAFpXaC584AIELa6pONV56MTpkm4Ha7gPWL2acNAjo=
 go.temporal.io/api v1.53.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/cloud-sdk v0.13.0 h1:Yhh6TEQG7xZgn8/A7C9WcxM+LS08qXlITRicuo2zGOA=
-go.temporal.io/cloud-sdk v0.13.0/go.mod h1:W2O9t9tvo3Q/LhGgYdj8JijWbN5C84os+cz/BadIHYI=
+go.temporal.io/cloud-sdk v0.14.1 h1:jZgnxyPHMY5+RhrTF5sd3sKlsSG4F2eQl3FCgiQEbrU=
+go.temporal.io/cloud-sdk v0.14.1/go.mod h1:W2O9t9tvo3Q/LhGgYdj8JijWbN5C84os+cz/BadIHYI=
 go.temporal.io/sdk v1.36.0 h1:WO9zetpybBNK7xsQth4Z+3Zzw1zSaM9MOUGrnnUjZMo=
 go.temporal.io/sdk v1.36.0/go.mod h1:8BxGRF0LcQlfQrLLGkgVajbsKUp/PY7280XTdcKc18Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/provider/enums/region.go
+++ b/internal/provider/enums/region.go
@@ -17,6 +17,8 @@ func FromRegionCloudProvider(p region.Region_CloudProvider) (string, error) {
 		return "aws", nil
 	case region.Region_CLOUD_PROVIDER_GCP:
 		return "gcp", nil
+	case region.Region_CLOUD_PROVIDER_AZURE:
+		return "azure", nil
 	default:
 		return "", fmt.Errorf("%w: %v", ErrInvalidRegionCloudProvider, p)
 	}

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -225,7 +225,7 @@ provider "temporalcloud" {
 
 resource "temporalcloud_namespace" "terraform" {
   name               = "%s"
-  regions            = ["azure-eastus"]
+  regions            = ["azure-centralus"]
   accepted_client_ca = base64encode(<<PEM
 -----BEGIN CERTIFICATE-----
 MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ

--- a/internal/provider/namespace_resource_test.go
+++ b/internal/provider/namespace_resource_test.go
@@ -215,6 +215,55 @@ resource "temporalcloud_namespace" "terraform" {
 	})
 }
 
+func TestAccBasicAzureNamespace(t *testing.T) {
+	name := fmt.Sprintf("%s-%s", "tf-azure-namespace", randomString(10))
+	config := func(name string, retention int) string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_namespace" "terraform" {
+  name               = "%s"
+  regions            = ["azure-eastus"]
+  accepted_client_ca = base64encode(<<PEM
+-----BEGIN CERTIFICATE-----
+MIIByDCCAU2gAwIBAgIRAuOeFDeADUx5O53PRIsIPZIwCgYIKoZIzj0EAwMwEjEQ
+MA4GA1UEChMHdGVzdGluZzAeFw0yNTA4MjAxNDAwMzNaFw0yNjA4MjAxNDAxMzNa
+MBIxEDAOBgNVBAoTB3Rlc3RpbmcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATRWwv2
+nVfToOR59QuRHk5jAVhu991AQWXwLFSzHzjmZ8XIkiVzh3EhPwybsnm+uV6XN/xe
+1+KJ/0NyiVL91KFwS0y5xLKqdvy/mOv0eSUy/blJpLR66diTqPDMlYntuBmjZzBl
+MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTNvOjx
+e/IC/jxLZvXGQT4fmj0eMTAjBgNVHREEHDAaghhjbGllbnQucm9vdC50ZXN0aW5n
+LjJ5cU4wCgYIKoZIzj0EAwMDaQAwZgIxALwxPDblJQ9R65G9/M7Tyx1H/7EUTeo9
+ThGIAJ5f8VReP9T7155ri5sRCUTBdgFHVAIxAOrtnTo8uRjEs8HdUW0e9H7E2nyW
+5hWHcfGvGFFkZn3TkJIX3kdJslSDmxOXhn7D/w==
+-----END CERTIFICATE-----
+PEM
+)
+  retention_days = %d
+}`, name, retention)
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(name, 7),
+			},
+			{
+				Config: config(name, 14),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      "temporalcloud_namespace.terraform",
+			},
+		},
+	})
+}
+
 func TestValidateRegionsWithConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/validators/region_validator.go
+++ b/internal/provider/validators/region_validator.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-var regionFormatPattern = regexp.MustCompile(`^(aws|gcp)-[a-z0-9-]+$`)
+var regionFormatPattern = regexp.MustCompile(`^(aws|gcp|azure)-[a-z0-9-]+$`)
 
 type regionFormatValidator struct{}
 
@@ -21,11 +21,11 @@ func RegionFormat() validator.String {
 }
 
 func (v *regionFormatValidator) Description(ctx context.Context) string {
-	return "must be a valid Temporal Cloud region format (e.g., aws-us-east-1, gcp-us-central1)"
+	return "must be a valid Temporal Cloud region format (e.g., aws-us-east-1, gcp-us-central1, azure-eastus)"
 }
 
 func (v *regionFormatValidator) MarkdownDescription(ctx context.Context) string {
-	return "must be a valid Temporal Cloud region format (e.g., `aws-us-east-1`, `gcp-us-central1`). See [available regions](https://docs.temporal.io/cloud/regions)."
+	return "must be a valid Temporal Cloud region format (e.g., `aws-us-east-1`, `gcp-us-central1`, `azure-eastus`). See [available regions](https://docs.temporal.io/cloud/regions)."
 }
 
 func (v *regionFormatValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
@@ -39,7 +39,7 @@ func (v *regionFormatValidator) ValidateString(ctx context.Context, req validato
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Invalid Region Format",
-			fmt.Sprintf("Region %q does not match expected format. Regions must be prefixed with cloud provider (e.g., aws-us-east-1, gcp-us-central1). See https://docs.temporal.io/cloud/regions", value),
+			fmt.Sprintf("Region %q does not match expected format. Regions must be prefixed with cloud provider (e.g., aws-us-east-1, gcp-us-central1, azure-eastus). See https://docs.temporal.io/cloud/regions", value),
 		)
 	}
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
As above
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes namespace region validation and cloud-provider mapping for real provisioning paths; risk is moderate but limited because behavior mirrors existing AWS/GCP support and is mostly additive.
> 
> **Overview**
> Adds **Azure** as a supported cloud prefix for `temporalcloud_namespace` `regions`, alongside existing AWS and GCP.
> 
> The provider bumps **`go.temporal.io/cloud-sdk`** to **v0.14.1**, maps `Region_CLOUD_PROVIDER_AZURE` to `"azure"` in region enum conversion, and extends the region format validator so values like `azure-centralus` pass schema validation (existence still checked via GetRegions at plan time). An acceptance test exercises create, update, and import for an Azure namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9197a948541e13307c07eb23994386346792c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->