### PR TITLE
Unify Access attributes between User and GroupAccess resources

### DIFF
--- a/docs/resources/group_access.md
+++ b/docs/resources/group_access.md
@@ -55,7 +55,7 @@ resource "temporalcloud_group_access" "my_group_access" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support. none is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.
+- `account_access` (String) The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.
 - `id` (String) The unique identifier of the group access across all Temporal Cloud tenants.
 
 ### Optional

--- a/docs/resources/group_access.md
+++ b/docs/resources/group_access.md
@@ -55,7 +55,7 @@ resource "temporalcloud_group_access" "my_group_access" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.
+- `account_access` (String) The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support.
 - `id` (String) The unique identifier of the group access across all Temporal Cloud tenants.
 
 ### Optional

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -74,7 +74,7 @@ resource "temporalcloud_apikey" "metrics" {
 
 ### Optional
 
-- `account_access` (String) The role on the account. Must be one of admin, developer, read, or metricsread (case-insensitive). Cannot be set if namespace_scoped_access is provided.
+- `account_access` (String) The role on the account. Must be one of `admin`, `developer`, `read`, `financeadmin`, or `metricsread` (case-insensitive). Cannot be set if namespace_scoped_access is provided.
 - `account_access_custom_roles` (Set of String) The set of custom role IDs assigned within account_access in addition to the built-in account_access role. Empty sets are not allowed, omit the attribute instead. Cannot be set if namespace_scoped_access is provided.
 - `description` (String) The description for the service account.
 - `namespace_accesses` (Attributes Set) The set of namespace accesses. Empty sets are not allowed, omit the attribute instead. Service Accounts with an account_access role of admin cannot be assigned explicit permissions to namespaces. Admins implicitly receive access to all Namespaces. Cannot be set if namespace_scoped_access is provided. (see [below for nested schema](#nestedatt--namespace_accesses))

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -54,7 +54,7 @@ resource "temporalcloud_user" "namespace_admin" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `metricsread` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships.
+- `account_access` (String) The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.
 - `email` (String) The email address for the user.
 
 ### Optional

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -54,7 +54,7 @@ resource "temporalcloud_user" "namespace_admin" {
 
 ### Required
 
-- `account_access` (String) The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.
+- `account_access` (String) The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. Users can only be set to `none` when they are managed by SCIM and derive their roles from group memberships.
 - `email` (String) The email address for the user.
 
 ### Optional

--- a/internal/provider/access.go
+++ b/internal/provider/access.go
@@ -34,10 +34,10 @@ var namespaceAccessAttrs = map[string]attr.Type{
 func addAccessSchemaAttrs(s schema.Schema) {
 	s.Attributes["account_access"] = schema.StringAttribute{
 		CustomType:  internaltypes.CaseInsensitiveStringType{},
-		Description: "The role on the account. Must be one of owner, admin, developer, none, or read (case-insensitive). owner is only valid for import and cannot be created, updated or deleted without Temporal support. none is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.",
+		Description: "The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.",
 		Required:    true,
 		Validators: []validator.String{
-			stringvalidator.OneOfCaseInsensitive("owner", "admin", "developer", "read", "none"),
+			stringvalidator.OneOfCaseInsensitive(enums.AllowedAccountAccessRolesForUsersAndGroups()...),
 		},
 	}
 

--- a/internal/provider/access.go
+++ b/internal/provider/access.go
@@ -31,10 +31,10 @@ var namespaceAccessAttrs = map[string]attr.Type{
 	"permission":   internaltypes.CaseInsensitiveStringType{},
 }
 
-func addAccessSchemaAttrs(s schema.Schema) {
+func addAccessSchemaAttrs(s *schema.Schema, accountDescriptionSuffix string) {
 	s.Attributes["account_access"] = schema.StringAttribute{
 		CustomType:  internaltypes.CaseInsensitiveStringType{},
-		Description: "The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships or for group access resources.",
+		Description: "The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `none` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support." + accountDescriptionSuffix,
 		Required:    true,
 		Validators: []validator.String{
 			stringvalidator.OneOfCaseInsensitive(enums.AllowedAccountAccessRolesForUsersAndGroups()...),

--- a/internal/provider/enums/identity.go
+++ b/internal/provider/enums/identity.go
@@ -57,9 +57,19 @@ func ToAccountAccessRole(s string) (identity.AccountAccess_Role, error) {
 	}
 }
 
-func AllowedAccountAccessRoles() []string {
+func AllowedAccountAccessRolesForUsersAndGroups() []string {
 	return []string{
 		"owner",
+		"admin",
+		"developer",
+		"read",
+		"financeadmin",
+		"none",
+	}
+}
+
+func AllowedAccountAccessRolesForServiceAccounts() []string {
+	return []string{
 		"admin",
 		"developer",
 		"read",

--- a/internal/provider/group_access_resource.go
+++ b/internal/provider/group_access_resource.go
@@ -106,7 +106,7 @@ func (r *groupAccessResource) Schema(_ context.Context, _ resource.SchemaRequest
 		},
 	}
 
-	addAccessSchemaAttrs(s)
+	addAccessSchemaAttrs(&s, "")
 	resp.Schema = s
 }
 

--- a/internal/provider/group_access_resource.go
+++ b/internal/provider/group_access_resource.go
@@ -179,7 +179,6 @@ func (r *groupAccessResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
-
 }
 
 func (r *groupAccessResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -322,7 +321,6 @@ func (r *groupAccessResource) Delete(ctx context.Context, req resource.DeleteReq
 		ResourceVersion:  currentGroup.GetGroup().GetResourceVersion(),
 		AsyncOperationId: uuid.New().String(),
 	})
-
 	if err != nil {
 		switch status.Code(err) {
 		case codes.NotFound:

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -127,10 +127,10 @@ func (r *serviceAccountResource) Schema(ctx context.Context, _ resource.SchemaRe
 			},
 			"account_access": schema.StringAttribute{
 				CustomType:  internaltypes.CaseInsensitiveStringType{},
-				Description: "The role on the account. Must be one of admin, developer, read, or metricsread (case-insensitive). Cannot be set if namespace_scoped_access is provided.",
+				Description: "The role on the account. Must be one of `admin`, `developer`, `read`, `financeadmin`, or `metricsread` (case-insensitive). Cannot be set if namespace_scoped_access is provided.",
 				Optional:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive(enums.AllowedAccountAccessRoles()...),
+					stringvalidator.OneOfCaseInsensitive(enums.AllowedAccountAccessRolesForServiceAccounts()...),
 					stringvalidator.ConflictsWith(path.Expressions{
 						path.MatchRoot("namespace_scoped_access"),
 					}...),

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
-	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -15,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -27,7 +24,6 @@ import (
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/client"
 	"github.com/temporalio/terraform-provider-temporalcloud/internal/provider/enums"
 	internaltypes "github.com/temporalio/terraform-provider-temporalcloud/internal/types"
-	"github.com/temporalio/terraform-provider-temporalcloud/internal/validation"
 )
 
 type (
@@ -90,7 +86,7 @@ func (r *userResource) Metadata(_ context.Context, req resource.MetadataRequest,
 }
 
 func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
+	s := schema.Schema{
 		Description: "Provisions a Temporal Cloud user.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -114,47 +110,6 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"account_access": schema.StringAttribute{
-				CustomType:  internaltypes.CaseInsensitiveStringType{},
-				Description: "The role on the account. Must be one of `owner`, `admin`, `developer`, `read`, `financeadmin`, or `metricsread` (case-insensitive). `owner` is only valid for import and cannot be created, updated or deleted without Temporal support. `none` is only valid for users managed via SCIM that derive their roles from group memberships.",
-				Required:    true,
-				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive(enums.AllowedAccountAccessRoles()...),
-				},
-			},
-			"account_access_custom_roles": schema.SetAttribute{
-				Description: accountAccessCustomRolesDescription,
-				Optional:    true,
-				ElementType: types.StringType,
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-				},
-			},
-			"namespace_accesses": schema.SetNestedAttribute{
-				Description: "The set of namespace accesses. Empty sets are not allowed, omit the attribute instead. Users with account_access roles of owner or admin cannot be assigned explicit permissions to namespaces. They implicitly receive access to all Namespaces.",
-				Optional:    true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"namespace_id": schema.StringAttribute{
-							Description: "The namespace to assign permissions to.",
-							Required:    true,
-						},
-						"permission": schema.StringAttribute{
-							CustomType:  internaltypes.CaseInsensitiveStringType{},
-							Description: "The permission to assign. Must be one of admin, write, or read (case-insensitive)",
-							Required:    true,
-							Validators: []validator.String{
-								stringvalidator.OneOfCaseInsensitive(enums.AllowedNamespaceAccessPermissions()...),
-							},
-						},
-					},
-				},
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					validation.NewNamespaceAccessValidator("account_access"),
-					validation.SetNestedAttributeMustBeUnique("namespace_id"),
-				},
-			},
 		},
 		Blocks: map[string]schema.Block{
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
@@ -163,6 +118,8 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 			}),
 		},
 	}
+	addAccessSchemaAttrs(s)
+	resp.Schema = s
 }
 
 func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -118,7 +118,7 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 			}),
 		},
 	}
-	addAccessSchemaAttrs(s)
+	addAccessSchemaAttrs(&s, " Users can only be set to `none` when they are managed by SCIM and derive their roles from group memberships.")
 	resp.Schema = s
 }
 


### PR DESCRIPTION
## What was changed
* unified access attributes between users and groups
* added missing `financeadmin` to the list of allowed roles
* removed `metricsread` from the user docs. `metricsread` is only available for service accounts

## Why?
Brings terraform in line with what the underlying APIs support

## Checklist

1. Closes CLDIAM-969, #404 

2. How was this tested: Wired these changes up to my local terraform, verified that I could create users and groups with `financeadmin`, verified that `metricsread` was rejected at the API level:

```
rpc error: code = InvalidArgument desc = metrics account role is not supported for user groups (type: bad-request, retryable: false)
rpc error: code = InvalidArgument desc = metrics account role is not supported for users (type: bad-request, retryable: false)
```

3. Any docs updates needed? This includes regenerated docs
