### PR TITLE
update audit log tests to use real values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,4 +86,6 @@ jobs:
       - env:
           TF_ACC: "1"
           TEMPORAL_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLOUD_API_KEY }}
+          INTEGRATION_TEST_AWS_ACCOUNT_ID: ${{ secrets.INTEGRATION_TEST_AWS_ACCOUNT_ID }}
+          INTEGRATION_TEST_GCP_PROJECT_ID: ${{ secrets.INTEGRATION_TEST_GCP_PROJECT_ID }}
         run: go test -timeout 60m -parallel 12 -v -cover ./internal/provider/

--- a/internal/provider/account_audit_log_sink_resource_datasource_test.go
+++ b/internal/provider/account_audit_log_sink_resource_datasource_test.go
@@ -31,7 +31,12 @@ func TestAccountAuditLogSinkResource_Schema(t *testing.T) {
 
 func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 	t.Parallel()
-	sinkRegion := "ca-central-1"
+	const (
+		kinesisRoleName          = "cloud-cicd-audit-log-external-trust-prod"
+		kinesisStreamArn         = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod"
+		kinesisStreamArnUpdated  = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod-updated"
+		kinesisRegion            = "us-west-2"
+	)
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
 	resource.Test(t, resource.TestCase{
@@ -40,20 +45,20 @@ func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccAccountAuditLogSinkKinesisConfig(sinkName, sinkRegion),
+				Config: testAccAccountAuditLogSinkKinesisConfig(sinkName, kinesisRoleName, kinesisStreamArn, kinesisRegion),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "enabled", "true"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.role_name", "test-role"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", "test-uri"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.region", sinkRegion),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.role_name", kinesisRoleName),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", kinesisStreamArn),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.region", kinesisRegion),
 					// Verify datasource
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "enabled", "true"),
 					resource.TestCheckResourceAttrSet("data.temporalcloud_account_audit_log_sink.test", "state"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.role_name", "test-role"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", "test-uri"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.region", sinkRegion),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.role_name", kinesisRoleName),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", kinesisStreamArn),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.region", kinesisRegion),
 				),
 			},
 			// ImportState testing
@@ -62,20 +67,20 @@ func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Update testing
+			// Update testing - only the Kinesis stream ARN changes
 			{
-				Config: testAccAccountAuditLogSinkKinesisConfigUpdate(sinkName, sinkRegion),
+				Config: testAccAccountAuditLogSinkKinesisConfigUpdate(sinkName, kinesisRoleName, kinesisStreamArnUpdated, kinesisRegion),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "enabled", "true"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.role_name", "test-updated-role"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", "test-updated-uri"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.region", sinkRegion),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.role_name", kinesisRoleName),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", kinesisStreamArnUpdated),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "kinesis.region", kinesisRegion),
 					// Verify datasource reflects updates
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "enabled", "true"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.role_name", "test-updated-role"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", "test-updated-uri"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.region", sinkRegion),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.role_name", kinesisRoleName),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.destination_uri", kinesisStreamArnUpdated),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "kinesis.region", kinesisRegion),
 				),
 			},
 			// Delete testing
@@ -90,6 +95,13 @@ func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 }
 
 func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
+	t.Parallel()
+	const (
+		pubsubServiceAccount   = "audit-log-cicd-prod"
+		pubsubTopicName        = "cloud-cicd-audit-log-prod"
+		pubsubTopicNameUpdated = "cloud-cicd-audit-log-prod-updated"
+		pubsubGCPProjectID     = "prod-t44kcfvuqwuazy9s3vuc2syu7"
+	)
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
 	resource.Test(t, resource.TestCase{
@@ -98,20 +110,20 @@ func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccAccountAuditLogSinkPubSubConfig(sinkName),
+				Config: testAccAccountAuditLogSinkPubSubConfig(sinkName, pubsubServiceAccount, pubsubTopicName, pubsubGCPProjectID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "enabled", "true"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", "test-sa"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", "test-topic"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", "test-project"),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicName),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
 					// Verify datasource
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "enabled", "true"),
 					resource.TestCheckResourceAttrSet("data.temporalcloud_account_audit_log_sink.test", "state"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", "test-sa"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", "test-topic"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", "test-project"),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicName),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
 				),
 			},
 			// ImportState testing
@@ -120,20 +132,20 @@ func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Update testing
+			// Update testing - only the topic name changes
 			{
-				Config: testAccAccountAuditLogSinkPubSubConfigUpdate(sinkName),
+				Config: testAccAccountAuditLogSinkPubSubConfigUpdate(sinkName, pubsubServiceAccount, pubsubTopicNameUpdated, pubsubGCPProjectID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "enabled", "true"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", "test-updated-sa"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", "test-updated-topic"),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", "test-updated-project"),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicNameUpdated),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
 					// Verify datasource reflects updates
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "enabled", "true"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", "test-updated-sa"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", "test-updated-topic"),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", "test-updated-project"),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicNameUpdated),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
 				),
 			},
 			// Delete testing
@@ -147,46 +159,46 @@ func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
 	})
 }
 
-func testAccAccountAuditLogSinkKinesisConfig(sinkName, sinkRegion string) string {
+func testAccAccountAuditLogSinkKinesisConfig(sinkName, roleName, streamArn, region string) string {
 	return fmt.Sprintf(`
 provider "temporalcloud" {
 }
 
 resource "temporalcloud_account_audit_log_sink" "test" {
-  sink_name    = %[1]q
-  enabled = true
+  sink_name = %[1]q
+  enabled   = true
   kinesis = {
-    role_name      = "test-role"
-    destination_uri = "test-uri"
-    region         = %[2]q
+    role_name       = %[2]q
+    destination_uri = %[3]q
+    region          = %[4]q
   }
 }
 
 data "temporalcloud_account_audit_log_sink" "test" {
   sink_name = temporalcloud_account_audit_log_sink.test.sink_name
 }
-`, sinkName, sinkRegion)
+`, sinkName, roleName, streamArn, region)
 }
 
-func testAccAccountAuditLogSinkKinesisConfigUpdate(sinkName, sinkRegion string) string {
+func testAccAccountAuditLogSinkKinesisConfigUpdate(sinkName, roleName, streamArn, region string) string {
 	return fmt.Sprintf(`
 resource "temporalcloud_account_audit_log_sink" "test" {
-  sink_name    = %[1]q
-  enabled = true
+  sink_name = %[1]q
+  enabled   = true
   kinesis = {
-    role_name      = "test-updated-role"
-    destination_uri = "test-updated-uri"
-    region         = %[2]q
+    role_name       = %[2]q
+    destination_uri = %[3]q
+    region          = %[4]q
   }
 }
 
 data "temporalcloud_account_audit_log_sink" "test" {
   sink_name = temporalcloud_account_audit_log_sink.test.sink_name
 }
-`, sinkName, sinkRegion)
+`, sinkName, roleName, streamArn, region)
 }
 
-func testAccAccountAuditLogSinkPubSubConfig(sinkName string) string {
+func testAccAccountAuditLogSinkPubSubConfig(sinkName, serviceAccountID, topicName, gcpProjectID string) string {
 	return fmt.Sprintf(`
 provider "temporalcloud" {
 }
@@ -195,32 +207,32 @@ resource "temporalcloud_account_audit_log_sink" "test" {
   sink_name = %[1]q
   enabled   = true
   pubsub = {
-    service_account_id = "test-sa"
-    topic_name         = "test-topic"
-    gcp_project_id     = "test-project"
+    service_account_id = %[2]q
+    topic_name         = %[3]q
+    gcp_project_id     = %[4]q
   }
 }
 
 data "temporalcloud_account_audit_log_sink" "test" {
   sink_name = temporalcloud_account_audit_log_sink.test.sink_name
 }
-`, sinkName)
+`, sinkName, serviceAccountID, topicName, gcpProjectID)
 }
 
-func testAccAccountAuditLogSinkPubSubConfigUpdate(sinkName string) string {
+func testAccAccountAuditLogSinkPubSubConfigUpdate(sinkName, serviceAccountID, topicName, gcpProjectID string) string {
 	return fmt.Sprintf(`
 resource "temporalcloud_account_audit_log_sink" "test" {
   sink_name = %[1]q
   enabled   = true
   pubsub = {
-    service_account_id = "test-updated-sa"
-    topic_name         = "test-updated-topic"
-    gcp_project_id     = "test-updated-project"
+    service_account_id = %[2]q
+    topic_name         = %[3]q
+    gcp_project_id     = %[4]q
   }
 }
 
 data "temporalcloud_account_audit_log_sink" "test" {
   sink_name = temporalcloud_account_audit_log_sink.test.sink_name
 }
-`, sinkName)
+`, sinkName, serviceAccountID, topicName, gcpProjectID)
 }

--- a/internal/provider/account_audit_log_sink_resource_datasource_test.go
+++ b/internal/provider/account_audit_log_sink_resource_datasource_test.go
@@ -32,10 +32,10 @@ func TestAccountAuditLogSinkResource_Schema(t *testing.T) {
 func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 	t.Parallel()
 	const (
-		kinesisRoleName          = "cloud-cicd-audit-log-external-trust-prod"
-		kinesisStreamArn         = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod"
-		kinesisStreamArnUpdated  = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod-updated"
-		kinesisRegion            = "us-west-2"
+		kinesisRoleName         = "cloud-cicd-audit-log-external-trust-prod"
+		kinesisStreamArn        = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod"
+		kinesisStreamArnUpdated = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod-updated"
+		kinesisRegion           = "us-west-2"
 	)
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 

--- a/internal/provider/account_audit_log_sink_resource_datasource_test.go
+++ b/internal/provider/account_audit_log_sink_resource_datasource_test.go
@@ -33,9 +33,6 @@ func TestAccountAuditLogSinkResource_Schema(t *testing.T) {
 func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 	t.Parallel()
 	awsAccountID := os.Getenv("INTEGRATION_TEST_AWS_ACCOUNT_ID")
-	if awsAccountID == "" {
-		t.Fatal("INTEGRATION_TEST_AWS_ACCOUNT_ID must be set for Kinesis audit log sink tests")
-	}
 	const (
 		kinesisRoleName = "cloud-cicd-audit-log-external-trust-prod"
 		kinesisRegion   = "us-west-2"
@@ -45,7 +42,12 @@ func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if awsAccountID == "" {
+				t.Fatal("INTEGRATION_TEST_AWS_ACCOUNT_ID must be set for Kinesis audit log sink tests")
+			}
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
@@ -101,9 +103,6 @@ func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 
 func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
 	gcpProjectID := os.Getenv("INTEGRATION_TEST_GCP_PROJECT_ID")
-	if gcpProjectID == "" {
-		t.Fatal("INTEGRATION_TEST_GCP_PROJECT_ID must be set for PubSub audit log sink tests")
-	}
 	const (
 		pubsubServiceAccount   = "audit-log-cicd-prod"
 		pubsubTopicName        = "cloud-cicd-audit-log-prod"
@@ -112,7 +111,12 @@ func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if gcpProjectID == "" {
+				t.Fatal("INTEGRATION_TEST_GCP_PROJECT_ID must be set for PubSub audit log sink tests")
+			}
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing

--- a/internal/provider/account_audit_log_sink_resource_datasource_test.go
+++ b/internal/provider/account_audit_log_sink_resource_datasource_test.go
@@ -95,7 +95,6 @@ func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 }
 
 func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
-	t.Parallel()
 	const (
 		pubsubServiceAccount   = "audit-log-cicd-prod"
 		pubsubTopicName        = "cloud-cicd-audit-log-prod"

--- a/internal/provider/account_audit_log_sink_resource_datasource_test.go
+++ b/internal/provider/account_audit_log_sink_resource_datasource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
@@ -31,12 +32,16 @@ func TestAccountAuditLogSinkResource_Schema(t *testing.T) {
 
 func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 	t.Parallel()
+	awsAccountID := os.Getenv("INTEGRATION_TEST_AWS_ACCOUNT_ID")
+	if awsAccountID == "" {
+		t.Fatal("INTEGRATION_TEST_AWS_ACCOUNT_ID must be set for Kinesis audit log sink tests")
+	}
 	const (
-		kinesisRoleName         = "cloud-cicd-audit-log-external-trust-prod"
-		kinesisStreamArn        = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod"
-		kinesisStreamArnUpdated = "arn:aws:kinesis:us-west-2:471170916252:stream/cloud-cicd-audit-log-prod-updated"
-		kinesisRegion           = "us-west-2"
+		kinesisRoleName = "cloud-cicd-audit-log-external-trust-prod"
+		kinesisRegion   = "us-west-2"
 	)
+	kinesisStreamArn := fmt.Sprintf("arn:aws:kinesis:%s:%s:stream/cloud-cicd-audit-log-prod", kinesisRegion, awsAccountID)
+	kinesisStreamArnUpdated := fmt.Sprintf("arn:aws:kinesis:%s:%s:stream/cloud-cicd-audit-log-prod-updated", kinesisRegion, awsAccountID)
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
 	resource.Test(t, resource.TestCase{
@@ -95,11 +100,14 @@ func TestAccAccountAuditLogSink_Kinesis(t *testing.T) {
 }
 
 func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
+	gcpProjectID := os.Getenv("INTEGRATION_TEST_GCP_PROJECT_ID")
+	if gcpProjectID == "" {
+		t.Fatal("INTEGRATION_TEST_GCP_PROJECT_ID must be set for PubSub audit log sink tests")
+	}
 	const (
 		pubsubServiceAccount   = "audit-log-cicd-prod"
 		pubsubTopicName        = "cloud-cicd-audit-log-prod"
 		pubsubTopicNameUpdated = "cloud-cicd-audit-log-prod-updated"
-		pubsubGCPProjectID     = "prod-t44kcfvuqwuazy9s3vuc2syu7"
 	)
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
@@ -109,20 +117,20 @@ func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccAccountAuditLogSinkPubSubConfig(sinkName, pubsubServiceAccount, pubsubTopicName, pubsubGCPProjectID),
+				Config: testAccAccountAuditLogSinkPubSubConfig(sinkName, pubsubServiceAccount, pubsubTopicName, gcpProjectID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicName),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", gcpProjectID),
 					// Verify datasource
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "enabled", "true"),
 					resource.TestCheckResourceAttrSet("data.temporalcloud_account_audit_log_sink.test", "state"),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicName),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", gcpProjectID),
 				),
 			},
 			// ImportState testing
@@ -133,18 +141,18 @@ func TestAccAccountAuditLogSink_PubSub(t *testing.T) {
 			},
 			// Update testing - only the topic name changes
 			{
-				Config: testAccAccountAuditLogSinkPubSubConfigUpdate(sinkName, pubsubServiceAccount, pubsubTopicNameUpdated, pubsubGCPProjectID),
+				Config: testAccAccountAuditLogSinkPubSubConfigUpdate(sinkName, pubsubServiceAccount, pubsubTopicNameUpdated, gcpProjectID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
 					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicNameUpdated),
-					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
+					resource.TestCheckResourceAttr("temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", gcpProjectID),
 					// Verify datasource reflects updates
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.service_account_id", pubsubServiceAccount),
 					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.topic_name", pubsubTopicNameUpdated),
-					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", pubsubGCPProjectID),
+					resource.TestCheckResourceAttr("data.temporalcloud_account_audit_log_sink.test", "pubsub.gcp_project_id", gcpProjectID),
 				),
 			},
 			// Delete testing

--- a/internal/provider/namespace_export_sink_resource_test.go
+++ b/internal/provider/namespace_export_sink_resource_test.go
@@ -32,9 +32,6 @@ func TestNamespaceExportSinkResource_Schema(t *testing.T) {
 
 func TestAccNamespaceExportSink_S3(t *testing.T) {
 	awsAccountID := os.Getenv("INTEGRATION_TEST_AWS_ACCOUNT_ID")
-	if awsAccountID == "" {
-		t.Fatal("INTEGRATION_TEST_AWS_ACCOUNT_ID must be set for S3 export sink tests")
-	}
 
 	namespaceName := fmt.Sprintf("tf-test-ns-export-aws-%s", randomString(8))
 	sinkRegion := "ca-central-1"
@@ -42,7 +39,12 @@ func TestAccNamespaceExportSink_S3(t *testing.T) {
 	sinkName := fmt.Sprintf("tf-test-sink-%s", randomString(8))
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if awsAccountID == "" {
+				t.Fatal("INTEGRATION_TEST_AWS_ACCOUNT_ID must be set for S3 export sink tests")
+			}
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
@@ -87,9 +89,6 @@ func TestAccNamespaceExportSink_S3(t *testing.T) {
 
 func TestAccNamespaceExportSink_GCS(t *testing.T) {
 	gcpProjectID := os.Getenv("INTEGRATION_TEST_GCP_PROJECT_ID")
-	if gcpProjectID == "" {
-		t.Fatal("INTEGRATION_TEST_GCP_PROJECT_ID must be set for GCS export sink tests")
-	}
 
 	namespaceName := fmt.Sprintf("tf-test-ns-export-gcp-%s", randomString(8))
 	sinkRegion := "us-central1"
@@ -115,7 +114,12 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if gcpProjectID == "" {
+				t.Fatal("INTEGRATION_TEST_GCP_PROJECT_ID must be set for GCS export sink tests")
+			}
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing

--- a/internal/provider/namespace_export_sink_resource_test.go
+++ b/internal/provider/namespace_export_sink_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
@@ -30,6 +31,10 @@ func TestNamespaceExportSinkResource_Schema(t *testing.T) {
 }
 
 func TestAccNamespaceExportSink_S3(t *testing.T) {
+	awsAccountID := os.Getenv("INTEGRATION_TEST_AWS_ACCOUNT_ID")
+	if awsAccountID == "" {
+		t.Fatal("INTEGRATION_TEST_AWS_ACCOUNT_ID must be set for S3 export sink tests")
+	}
 
 	namespaceName := fmt.Sprintf("tf-test-ns-export-aws-%s", randomString(8))
 	sinkRegion := "ca-central-1"
@@ -42,14 +47,14 @@ func TestAccNamespaceExportSink_S3(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccNamespaceExportSinkS3Config(namespaceName, sinkName, namespaceRegion, sinkRegion),
+				Config: testAccNamespaceExportSinkS3Config(namespaceName, sinkName, namespaceRegion, sinkRegion, awsAccountID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "sink_name", sinkName),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.bucket_name", "cloud-cicd-export-prod-cacentral1"),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.region", sinkRegion),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.role_name", "cloud-cicd-export-external-trust-prod-cacentral1"),
-					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.aws_account_id", "471170916252"),
+					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.aws_account_id", awsAccountID),
 				),
 			},
 			// ImportState testing
@@ -60,13 +65,13 @@ func TestAccNamespaceExportSink_S3(t *testing.T) {
 			},
 			// Update testing
 			{
-				Config: testAccNamespaceExportSinkS3ConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion),
+				Config: testAccNamespaceExportSinkS3ConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, awsAccountID),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "enabled", "false"),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.bucket_name", "cloud-cicd-export-prod-cacentral1-updated"),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.role_name", "cloud-cicd-export-external-trust-prod-cacentral1"),
 					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.region", sinkRegion),
-					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.aws_account_id", "471170916252"),
+					resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "s3.aws_account_id", awsAccountID),
 				),
 			},
 			// Delete testing
@@ -81,6 +86,11 @@ func TestAccNamespaceExportSink_S3(t *testing.T) {
 }
 
 func TestAccNamespaceExportSink_GCS(t *testing.T) {
+	gcpProjectID := os.Getenv("INTEGRATION_TEST_GCP_PROJECT_ID")
+	if gcpProjectID == "" {
+		t.Fatal("INTEGRATION_TEST_GCP_PROJECT_ID must be set for GCS export sink tests")
+	}
+
 	namespaceName := fmt.Sprintf("tf-test-ns-export-gcp-%s", randomString(8))
 	sinkRegion := "us-central1"
 	namespaceRegion := fmt.Sprintf("gcp-%s", sinkRegion)
@@ -93,7 +103,7 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.bucket_name", "prod-export-saas-cicd"),
 		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.region", sinkRegion),
 		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.service_account_id", "export-prod"),
-		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.gcp_project_id", "prod-t44kcfvuqwuazy9s3vuc2syu7"),
+		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.gcp_project_id", gcpProjectID),
 	)
 
 	updateGCSCheckFun := resource.ComposeAggregateTestCheckFunc(
@@ -101,7 +111,7 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.bucket_name", "prod-export-saas-cicd-updated"),
 		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.region", sinkRegion),
 		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.service_account_id", "export-prod"),
-		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.gcp_project_id", "prod-t44kcfvuqwuazy9s3vuc2syu7"),
+		resource.TestCheckResourceAttr("temporalcloud_namespace_export_sink.test", "gcs.gcp_project_id", gcpProjectID),
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -110,7 +120,7 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccNamespaceExportSinkGCSConfig(namespaceName, namespaceRegion, sinkName, sinkRegion, false),
+				Config: testAccNamespaceExportSinkGCSConfig(namespaceName, namespaceRegion, sinkName, sinkRegion, gcpProjectID, false),
 				Check:  creationGCSCheckFun,
 			},
 			// ImportState testing
@@ -121,7 +131,7 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 			},
 			// Update with SA email
 			{
-				Config: testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, true),
+				Config: testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, gcpProjectID, true),
 				Check:  updateGCSCheckFun,
 			},
 			// Delete testing
@@ -133,12 +143,12 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 			},
 			// Create with SA email
 			{
-				Config: testAccNamespaceExportSinkGCSConfig(namespaceName, namespaceRegion, sinkName, sinkRegion, true),
+				Config: testAccNamespaceExportSinkGCSConfig(namespaceName, namespaceRegion, sinkName, sinkRegion, gcpProjectID, true),
 				Check:  creationGCSCheckFun,
 			},
 			// Update with not SA email
 			{
-				Config: testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, false),
+				Config: testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, gcpProjectID, false),
 				Check:  updateGCSCheckFun,
 			},
 			// ImportState testing
@@ -149,7 +159,7 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 			},
 			// Update with SA email
 			{
-				Config: testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, true),
+				Config: testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, gcpProjectID, true),
 				Check:  updateGCSCheckFun,
 			},
 			// Delete testing
@@ -163,7 +173,7 @@ func TestAccNamespaceExportSink_GCS(t *testing.T) {
 	})
 }
 
-func testAccNamespaceExportSinkS3Config(namespaceName, sinkName, namespaceRegion, sinkregion string) string {
+func testAccNamespaceExportSinkS3Config(namespaceName, sinkName, namespaceRegion, sinkregion, awsAccountID string) string {
 	return fmt.Sprintf(`
 provider "temporalcloud" {
 }
@@ -183,14 +193,14 @@ resource "temporalcloud_namespace_export_sink" "test" {
     bucket_name    = "cloud-cicd-export-prod-cacentral1"
     region         = %[4]q
     role_name      = "cloud-cicd-export-external-trust-prod-cacentral1"
-    aws_account_id = "471170916252"
+    aws_account_id = %[5]q
   }
 
 }
-`, namespaceName, namespaceRegion, sinkName, sinkregion)
+`, namespaceName, namespaceRegion, sinkName, sinkregion, awsAccountID)
 }
 
-func testAccNamespaceExportSinkS3ConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion string) string {
+func testAccNamespaceExportSinkS3ConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, awsAccountID string) string {
 	return fmt.Sprintf(`
 resource "temporalcloud_namespace" "terraform" {
   name               = %[1]q
@@ -207,13 +217,13 @@ resource "temporalcloud_namespace_export_sink" "test" {
     bucket_name    = "cloud-cicd-export-prod-cacentral1-updated"
     region         = %[4]q
     role_name      = "cloud-cicd-export-external-trust-prod-cacentral1"
-    aws_account_id = "471170916252"
+    aws_account_id = %[5]q
   }
 }
-`, namespaceName, namespaceRegion, sinkName, sinkRegion)
+`, namespaceName, namespaceRegion, sinkName, sinkRegion, awsAccountID)
 }
 
-func testAccNamespaceExportSinkGCSConfig(namespaceName, namespaceRegion, sinkName, sinkRegion string, isSAEmail bool) string {
+func testAccNamespaceExportSinkGCSConfig(namespaceName, namespaceRegion, sinkName, sinkRegion, gcpProjectID string, isSAEmail bool) string {
 	var export_config string
 	if !isSAEmail {
 		export_config = fmt.Sprintf(`
@@ -221,17 +231,17 @@ func testAccNamespaceExportSinkGCSConfig(namespaceName, namespaceRegion, sinkNam
     bucket_name         = "prod-export-saas-cicd"
     region              = %[1]q
     service_account_id  = "export-prod"
-    gcp_project_id      = "prod-t44kcfvuqwuazy9s3vuc2syu7"
+    gcp_project_id      = %[2]q
   }	
-`, sinkRegion)
+`, sinkRegion, gcpProjectID)
 	} else {
 		export_config = fmt.Sprintf(`
   gcs = {
     bucket_name     = "prod-export-saas-cicd"
     region          = %[1]q
-    service_account_email = "export-prod@prod-t44kcfvuqwuazy9s3vuc2syu7.iam.gserviceaccount.com"
+    service_account_email = "export-prod@%[2]s.iam.gserviceaccount.com"
   }
-`, sinkRegion)
+`, sinkRegion, gcpProjectID)
 	}
 
 	return fmt.Sprintf(`
@@ -255,7 +265,7 @@ resource "temporalcloud_namespace_export_sink" "test" {
 `, namespaceName, namespaceRegion, sinkName, export_config)
 }
 
-func testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion string, isSAEmail bool) string {
+func testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, sinkName, sinkRegion, gcpProjectID string, isSAEmail bool) string {
 	var export_config string
 	if !isSAEmail {
 		export_config = fmt.Sprintf(`
@@ -263,17 +273,17 @@ func testAccNamespaceExportSinkGCSConfigUpdate(namespaceName, namespaceRegion, s
     bucket_name         = "prod-export-saas-cicd-updated"
     region              = %[1]q
     service_account_id  = "export-prod"
-    gcp_project_id      = "prod-t44kcfvuqwuazy9s3vuc2syu7"
+    gcp_project_id      = %[2]q
   }
-`, sinkRegion)
+`, sinkRegion, gcpProjectID)
 	} else {
 		export_config = fmt.Sprintf(`
   gcs = {
     bucket_name     = "prod-export-saas-cicd-updated"
     region          = %[1]q
-    service_account_email = "export-prod@prod-t44kcfvuqwuazy9s3vuc2syu7.iam.gserviceaccount.com"
+    service_account_email = "export-prod@%[2]s.iam.gserviceaccount.com"
   }
-`, sinkRegion)
+`, sinkRegion, gcpProjectID)
 	}
 
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
uses some real infra to test properly audit log sink validation
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to acceptance tests and CI env wiring; no provider runtime or resource logic is modified.
> 
> **Overview**
> Acceptance tests for **account audit log sinks** (Kinesis and Pub/Sub) and **namespace export sinks** (S3 and GCS) now use real CICD infrastructure identifiers instead of placeholder strings, so Temporal Cloud can validate sink configuration during `TF_ACC` runs.
> 
> CI injects `INTEGRATION_TEST_AWS_ACCOUNT_ID` and `INTEGRATION_TEST_GCP_PROJECT_ID` from GitHub secrets into the provider acceptance job. Tests read those env vars in `PreCheck` and fail fast with a clear message if they are missing. Kinesis tests build stream ARNs from the AWS account ID and fixed role/stream names; Pub/Sub and GCS tests use shared service account and topic/bucket names with the GCP project ID from env (including dynamic service-account email formatting).
> 
> Update steps are tightened: Kinesis updates change only the destination stream ARN; Pub/Sub updates change only the topic name. Namespace export sink helpers no longer hardcode a specific AWS account or GCP project ID—they take the same env-driven values as the assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b532f928f84de33104f0e572dfecb28bf007c31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->