### PR TITLE
Fix custom_role resource_type wire format

### DIFF
--- a/docs/resources/custom_role.md
+++ b/docs/resources/custom_role.md
@@ -33,7 +33,7 @@ resource "temporalcloud_custom_role" "example_custom_role" {
     {
       actions = ["cloud.account.get"]
       resources = {
-        resource_type = "account"
+        resource_type = "accounts"
         resource_ids  = []
         allow_all     = true
       }
@@ -74,7 +74,7 @@ Required:
 Required:
 
 - `resource_ids` (Set of String) The resource IDs this permission applies to. If empty, allow_all must be true.
-- `resource_type` (String) The resource type this permission applies to.
+- `resource_type` (String) The resource type this permission applies to. Must be one of: accounts, projects, namespaces, nexus-endpoints, connectivity-rules, custom-roles.
 
 Optional:
 

--- a/examples/resources/temporalcloud_custom_role/resource.tf
+++ b/examples/resources/temporalcloud_custom_role/resource.tf
@@ -18,7 +18,7 @@ resource "temporalcloud_custom_role" "example_custom_role" {
     {
       actions = ["cloud.account.get"]
       resources = {
-        resource_type = "account"
+        resource_type = "accounts"
         resource_ids  = []
         allow_all     = true
       }

--- a/internal/provider/custom_role_resource.go
+++ b/internal/provider/custom_role_resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -147,8 +148,11 @@ func (r *customRoleResource) Schema(ctx context.Context, _ resource.SchemaReques
 							Required:    true,
 							Attributes: map[string]schema.Attribute{
 								"resource_type": schema.StringAttribute{
-									Description: "The resource type this permission applies to.",
+									Description: "The resource type this permission applies to. Must be one of: accounts, projects, namespaces, nexus-endpoints, connectivity-rules, custom-roles.",
 									Required:    true,
+									Validators: []validator.String{
+										stringvalidator.OneOf(enums.CustomRoleResourceTypes...),
+									},
 								},
 								"resource_ids": schema.SetAttribute{
 									Description: "The resource IDs this permission applies to. If empty, allow_all must be true.",

--- a/internal/provider/custom_role_resource_test.go
+++ b/internal/provider/custom_role_resource_test.go
@@ -49,7 +49,7 @@ func TestUpdateCustomRoleModelFromSpecPreservesEmptyResourceIDs(t *testing.T) {
 				{
 					Actions: []string{"cloud.account.get"},
 					Resources: &identityv1.CustomRoleSpec_Resources{
-						ResourceType: "account",
+						ResourceType: "accounts",
 						ResourceIds:  nil,
 						AllowAll:     true,
 					},
@@ -147,7 +147,7 @@ func TestValidateCustomRolePermissions(t *testing.T) {
 					types.ObjectValueMust(customRolePermissionAttrs, map[string]attr.Value{
 						"actions": types.SetValueMust(types.StringType, []attr.Value{types.StringValue("cloud.account.get")}),
 						"resources": types.ObjectValueMust(customRoleResourcesAttrs, map[string]attr.Value{
-							"resource_type": types.StringValue("account"),
+							"resource_type": types.StringValue("accounts"),
 							"resource_ids":  tc.resourceIDs,
 							"allow_all":     tc.allowAll,
 						}),

--- a/internal/provider/enums/custom_role_resource_type.go
+++ b/internal/provider/enums/custom_role_resource_type.go
@@ -1,0 +1,14 @@
+package enums
+
+// CustomRoleResourceTypes are the wire-format values accepted by the Cloud Ops API
+// for CustomRoleSpec.Resources.resource_type.
+//
+// Source of truth: https://github.com/temporalio/saas-auth/blob/main/resources/resources.go
+var CustomRoleResourceTypes = []string{
+	"accounts",
+	"projects",
+	"namespaces",
+	"nexus-endpoints",
+	"connectivity-rules",
+	"custom-roles",
+}

--- a/internal/provider/enums/custom_role_resource_type_test.go
+++ b/internal/provider/enums/custom_role_resource_type_test.go
@@ -1,0 +1,26 @@
+package enums
+
+import "testing"
+
+func TestCustomRoleResourceTypes(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		"accounts",
+		"projects",
+		"namespaces",
+		"nexus-endpoints",
+		"connectivity-rules",
+		"custom-roles",
+	}
+
+	if len(CustomRoleResourceTypes) != len(want) {
+		t.Fatalf("expected %d resource types, got %d", len(want), len(CustomRoleResourceTypes))
+	}
+
+	for i, value := range want {
+		if CustomRoleResourceTypes[i] != value {
+			t.Fatalf("expected resource type %q at index %d, got %q", value, i, CustomRoleResourceTypes[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Corrects the `temporalcloud_custom_role` example and docs to use `resource_type = "accounts"` instead of `"account"`.
- Adds plan-time validation (`stringvalidator.OneOf`) for the six wire-format values the Cloud Ops API accepts: `accounts`, `projects`, `namespaces`, `nexus-endpoints`, `connectivity-rules`, `custom-roles`.
- Centralizes allowed values in `internal/provider/enums/custom_role_resource_type.go`.

**Context:** `CustomRoleSpec.Resources.resource_type` is a plain string in the proto, but the control plane validates against the allowlist in `saas-auth/resources` (plural kebab-case). The authz proto enum `RESOURCE_TYPE_ACCOUNT` is a different concept and does not map to `"Account"` or `"account"` as wire values.

**Verified on staging** (`temporal-dev` via `saas-api.tmprl-test.cloud`):
- `"accounts"` — create/read/delete succeeded
- `"account"` — `InvalidArgument: invalid resource type: account`

## Test plan

- [x] `go test ./internal/provider -run CustomRole`
- [x] `go test ./internal/provider/enums -run TestCustomRoleResourceTypes`
- [x] Live API test on staging account `temporal-dev`


Made with [Cursor](https://cursor.com)