### PR TITLE
Add azure support for connectivity rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,4 +88,5 @@ jobs:
           TEMPORAL_CLOUD_API_KEY: ${{ secrets.TEMPORAL_CLOUD_API_KEY }}
           INTEGRATION_TEST_AWS_ACCOUNT_ID: ${{ secrets.INTEGRATION_TEST_AWS_ACCOUNT_ID }}
           INTEGRATION_TEST_GCP_PROJECT_ID: ${{ secrets.INTEGRATION_TEST_GCP_PROJECT_ID }}
+          INTEGRATION_TEST_AZURE_SUBSCRIPTION_ID: ${{ secrets.INTEGRATION_TEST_AZURE_SUBSCRIPTION_ID }}
         run: go test -timeout 60m -parallel 12 -v -cover ./internal/provider/

--- a/docs/data-sources/connectivity_rule.md
+++ b/docs/data-sources/connectivity_rule.md
@@ -21,6 +21,7 @@ Fetches details about a connectivity rule.
 
 ### Read-Only
 
+- `azure_pe_resource_id` (String) The ARM resource ID of the Azure Private Endpoint for the connectivity rule.
 - `connection_id` (String) The ID of the connection to the connectivity rule.
 - `connectivity_type` (String) The type of connectivity.
 - `created_at` (String) The time the connectivity rule was created.

--- a/docs/data-sources/connectivity_rule.md
+++ b/docs/data-sources/connectivity_rule.md
@@ -21,7 +21,7 @@ Fetches details about a connectivity rule.
 
 ### Read-Only
 
-- `azure_pe_resource_id` (String) The ARM resource ID of the Azure Private Endpoint for the connectivity rule.
+- `azure_pe_resource_id` (String) The ARM resource ID of the customer's Azure Private Endpoint for the connectivity rule.
 - `connection_id` (String) The ID of the connection to the connectivity rule.
 - `connectivity_type` (String) The type of connectivity.
 - `created_at` (String) The time the connectivity rule was created.

--- a/docs/resources/connectivity_rule.md
+++ b/docs/resources/connectivity_rule.md
@@ -54,7 +54,7 @@ resource "temporalcloud_connectivity_rule" "private_gcp" {
 // Create Private Connectivity Rule for Azure
 resource "temporalcloud_connectivity_rule" "private_azure" {
   connectivity_type    = "private"
-  region               = "azure-eastus"
+  region               = "azure-centralus"
   azure_pe_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/privateEndpoints/my-pe"
 }
 
@@ -79,11 +79,11 @@ resource "temporalcloud_namespace" "ns-with-cr" {
 
 ### Optional
 
-- `azure_pe_resource_id` (String) The ARM resource ID of the customer's Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.
+- `azure_pe_resource_id` (String) The ARM resource ID of the Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.
 - `connection_id` (String) The connection ID of the private connection. Not applicable for Azure, where this is populated automatically after the Private Endpoint connection is approved.
 - `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.
 - `gcp_project_id` (String) The GCP project ID. Required when region is 'gcp'.
-- `region` (String) The region of the connection. Example: 'aws-us-west-2', 'gcp-us-central1', 'azure-eastus'.
+- `region` (String) The region of the connection. Example: 'aws-us-west-2', 'gcp-us-central1', 'azure-centralus'.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/connectivity_rule.md
+++ b/docs/resources/connectivity_rule.md
@@ -79,7 +79,7 @@ resource "temporalcloud_namespace" "ns-with-cr" {
 
 ### Optional
 
-- `azure_pe_resource_id` (String) The ARM resource ID of the customer's Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.
+- `azure_pe_resource_id` (String) The ARM resource ID of the customer's Azure Private Endpoint. Required when region starts with 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.
 - `connection_id` (String) The connection ID of the private connection. Not applicable for Azure, where this is populated automatically after the Private Endpoint connection is approved.
 - `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.
 - `gcp_project_id` (String) The GCP project ID. Required when region is 'gcp'.

--- a/docs/resources/connectivity_rule.md
+++ b/docs/resources/connectivity_rule.md
@@ -79,7 +79,7 @@ resource "temporalcloud_namespace" "ns-with-cr" {
 
 ### Optional
 
-- `azure_pe_resource_id` (String) The ARM resource ID of the Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.
+- `azure_pe_resource_id` (String) The ARM resource ID of the customer's Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.
 - `connection_id` (String) The connection ID of the private connection. Not applicable for Azure, where this is populated automatically after the Private Endpoint connection is approved.
 - `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.
 - `gcp_project_id` (String) The GCP project ID. Required when region is 'gcp'.

--- a/docs/resources/connectivity_rule.md
+++ b/docs/resources/connectivity_rule.md
@@ -51,6 +51,13 @@ resource "temporalcloud_connectivity_rule" "private_gcp" {
   gcp_project_id    = "my-gcp-project-id"
 }
 
+// Create Private Connectivity Rule for Azure
+resource "temporalcloud_connectivity_rule" "private_azure" {
+  connectivity_type    = "private"
+  region               = "azure-eastus"
+  azure_pe_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/privateEndpoints/my-pe"
+}
+
 // Attaching connectivity rules to a namespace
 resource "temporalcloud_namespace" "ns-with-cr" {
   name           = "ns-with-cr"
@@ -72,10 +79,11 @@ resource "temporalcloud_namespace" "ns-with-cr" {
 
 ### Optional
 
-- `connection_id` (String) The connection ID of the private connection.
+- `azure_pe_resource_id` (String) The ARM resource ID of the customer's Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.
+- `connection_id` (String) The connection ID of the private connection. Not applicable for Azure, where this is populated automatically after the Private Endpoint connection is approved.
 - `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.
-- `gcp_project_id` (String) The GCP project ID. Required when cloud_provider is 'gcp'.
-- `region` (String) The region of the connection. Example: 'aws-us-west-2'.
+- `gcp_project_id` (String) The GCP project ID. Required when region is 'gcp'.
+- `region` (String) The region of the connection. Example: 'aws-us-west-2', 'gcp-us-central1', 'azure-eastus'.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/examples/resources/temporalcloud_connectivity_rule/resource.tf
+++ b/examples/resources/temporalcloud_connectivity_rule/resource.tf
@@ -36,6 +36,13 @@ resource "temporalcloud_connectivity_rule" "private_gcp" {
   gcp_project_id    = "my-gcp-project-id"
 }
 
+// Create Private Connectivity Rule for Azure
+resource "temporalcloud_connectivity_rule" "private_azure" {
+  connectivity_type    = "private"
+  region               = "azure-eastus"
+  azure_pe_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/privateEndpoints/my-pe"
+}
+
 // Attaching connectivity rules to a namespace
 resource "temporalcloud_namespace" "ns-with-cr" {
   name           = "ns-with-cr"

--- a/examples/resources/temporalcloud_connectivity_rule/resource.tf
+++ b/examples/resources/temporalcloud_connectivity_rule/resource.tf
@@ -39,7 +39,7 @@ resource "temporalcloud_connectivity_rule" "private_gcp" {
 // Create Private Connectivity Rule for Azure
 resource "temporalcloud_connectivity_rule" "private_azure" {
   connectivity_type    = "private"
-  region               = "azure-eastus"
+  region               = "azure-centralus"
   azure_pe_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Network/privateEndpoints/my-pe"
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	github.com/jpillora/maplock v0.0.0-20160420012925-5c725ac6e22a
 	go.temporal.io/api v1.53.0
-	go.temporal.io/cloud-sdk v0.14.1
+	go.temporal.io/cloud-sdk v0.15.0
 	go.temporal.io/sdk v1.36.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.9

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.temporal.io/api v1.53.0 h1:6vAFpXaC584AIELa6pONV56MTpkm4Ha7gPWL2acNAjo=
 go.temporal.io/api v1.53.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/cloud-sdk v0.14.1 h1:jZgnxyPHMY5+RhrTF5sd3sKlsSG4F2eQl3FCgiQEbrU=
-go.temporal.io/cloud-sdk v0.14.1/go.mod h1:W2O9t9tvo3Q/LhGgYdj8JijWbN5C84os+cz/BadIHYI=
+go.temporal.io/cloud-sdk v0.15.0 h1:TwlGhTVnF7d9uIP5wjV/vr7TBYsPEpJw/MNuiylX3DQ=
+go.temporal.io/cloud-sdk v0.15.0/go.mod h1:W2O9t9tvo3Q/LhGgYdj8JijWbN5C84os+cz/BadIHYI=
 go.temporal.io/sdk v1.36.0 h1:WO9zetpybBNK7xsQth4Z+3Zzw1zSaM9MOUGrnnUjZMo=
 go.temporal.io/sdk v1.36.0/go.mod h1:8BxGRF0LcQlfQrLLGkgVajbsKUp/PY7280XTdcKc18Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/provider/connectivity_rule_datasource.go
+++ b/internal/provider/connectivity_rule_datasource.go
@@ -30,12 +30,13 @@ type (
 	}
 
 	connectivityRuleDataModel struct {
-		ID               types.String `tfsdk:"id"`
-		ConnectivityType types.String `tfsdk:"connectivity_type"`
-		ConnectionID     types.String `tfsdk:"connection_id"`
-		Region           types.String `tfsdk:"region"`
-		GcpProjectID     types.String `tfsdk:"gcp_project_id"`
-		EnableStableIps  types.Bool   `tfsdk:"enable_stable_ips"`
+		ID                types.String `tfsdk:"id"`
+		ConnectivityType  types.String `tfsdk:"connectivity_type"`
+		ConnectionID      types.String `tfsdk:"connection_id"`
+		Region            types.String `tfsdk:"region"`
+		GcpProjectID      types.String `tfsdk:"gcp_project_id"`
+		AzurePeResourceID types.String `tfsdk:"azure_pe_resource_id"`
+		EnableStableIps   types.Bool   `tfsdk:"enable_stable_ips"`
 
 		State     types.String `tfsdk:"state"`
 		CreatedAt types.String `tfsdk:"created_at"`
@@ -71,6 +72,10 @@ func connectivityRuleDataSourceSchema(idRequired bool) map[string]schema.Attribu
 		"gcp_project_id": schema.StringAttribute{
 			Computed:    true,
 			Description: "The GCP project ID of the connectivity rule.",
+		},
+		"azure_pe_resource_id": schema.StringAttribute{
+			Computed:    true,
+			Description: "The ARM resource ID of the customer's Azure Private Endpoint for the connectivity rule.",
 		},
 		"enable_stable_ips": schema.BoolAttribute{
 			Computed:    true,
@@ -170,11 +175,17 @@ func connectivityRuleToConnectivityRuleDataModel(connectivityRule *connectivityr
 		} else {
 			model.GcpProjectID = types.StringNull()
 		}
+		if connectivityRule.GetSpec().GetPrivateRule().GetAzurePeResourceId() != "" {
+			model.AzurePeResourceID = types.StringValue(connectivityRule.GetSpec().GetPrivateRule().GetAzurePeResourceId())
+		} else {
+			model.AzurePeResourceID = types.StringNull()
+		}
 	} else if connectivityRule.GetSpec().GetPublicRule() != nil {
 		model.ConnectivityType = types.StringValue(connectivityRuleTypePublic)
 		model.ConnectionID = types.StringNull()
 		model.Region = types.StringNull()
 		model.GcpProjectID = types.StringNull()
+		model.AzurePeResourceID = types.StringNull()
 		model.EnableStableIps = types.BoolValue(connectivityRule.GetSpec().GetPublicRule().GetEnableStableIps())
 	} else {
 		diags.AddError("Invalid connectivity rule", "connectivity rule must be either public or private")

--- a/internal/provider/connectivity_rule_datasource_test.go
+++ b/internal/provider/connectivity_rule_datasource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -177,6 +178,95 @@ output "connectivity_rule" {
 					// For AWS private connectivity rules, gcp_project_id should be null
 					if gcpProjectID, exists := outputValue["gcp_project_id"]; exists && gcpProjectID != nil {
 						return fmt.Errorf("expected gcp_project_id to be null for AWS private connectivity rule")
+					}
+
+					// For AWS private connectivity rules, azure_pe_resource_id should be null
+					if azurePeResourceID, exists := outputValue["azure_pe_resource_id"]; exists && azurePeResourceID != nil {
+						return fmt.Errorf("expected azure_pe_resource_id to be null for AWS private connectivity rule")
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccDataSource_ConnectivityRule_Azure_Private(t *testing.T) {
+	subscriptionID := os.Getenv("INTEGRATION_TEST_AZURE_SUBSCRIPTION_ID")
+	azurePeResourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-saas-cicd-prod/providers/Microsoft.Network/privateEndpoints/temporal-pe", subscriptionID)
+
+	config := func() string {
+		return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_connectivity_rule" "test_azure_private" {
+  connectivity_type    = "private"
+  region               = "azure-centralus"
+  azure_pe_resource_id = %[1]q
+}
+
+data "temporalcloud_connectivity_rule" "test_azure_private" {
+  id = temporalcloud_connectivity_rule.test_azure_private.id
+}
+
+output "connectivity_rule" {
+  value = data.temporalcloud_connectivity_rule.test_azure_private
+}
+`, azurePeResourceID)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if subscriptionID == "" {
+				t.Fatal("INTEGRATION_TEST_AZURE_SUBSCRIPTION_ID must be set for Azure connectivity rule tests")
+			}
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(),
+				Check: func(s *terraform.State) error {
+					output, ok := s.RootModule().Outputs["connectivity_rule"]
+					if !ok {
+						return fmt.Errorf("missing expected output")
+					}
+
+					outputValue, ok := output.Value.(map[string]interface{})
+					if !ok {
+						return fmt.Errorf("expected value to be map")
+					}
+
+					outputConnectivityType, ok := outputValue["connectivity_type"].(string)
+					if !ok {
+						return fmt.Errorf("expected connectivity_type to be a string")
+					}
+					if outputConnectivityType != "private" {
+						return fmt.Errorf("expected connectivity_type to be 'private', got: %s", outputConnectivityType)
+					}
+
+					outputRegion, ok := outputValue["region"].(string)
+					if !ok {
+						return fmt.Errorf("expected region to be a string")
+					}
+					if outputRegion != "azure-centralus" {
+						return fmt.Errorf("expected region to be 'azure-centralus', got: %s", outputRegion)
+					}
+
+					outputAzurePeResourceID, ok := outputValue["azure_pe_resource_id"].(string)
+					if !ok {
+						return fmt.Errorf("expected azure_pe_resource_id to be a string")
+					}
+					if outputAzurePeResourceID != azurePeResourceID {
+						return fmt.Errorf("expected azure_pe_resource_id to match, got: %s", outputAzurePeResourceID)
+					}
+
+					// For Azure private connectivity rules, gcp_project_id should be null
+					if gcpProjectID, exists := outputValue["gcp_project_id"]; exists && gcpProjectID != nil {
+						return fmt.Errorf("expected gcp_project_id to be null for Azure private connectivity rule")
 					}
 
 					return nil

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -113,7 +113,7 @@ func (r *connectivityRuleResource) Schema(ctx context.Context, _ resource.Schema
 				Optional:    true,
 			},
 			"azure_pe_resource_id": schema.StringAttribute{
-				Description: "The ARM resource ID of the customer's Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.",
+				Description: "The ARM resource ID of the customer's Azure Private Endpoint. Required when region starts with 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.",
 				Optional:    true,
 			},
 			"region": schema.StringAttribute{
@@ -362,6 +362,7 @@ func updateConnectivityRuleModelFromSpec(model *connectivityRuleResourceModel, c
 	var diags diag.Diagnostics
 
 	model.ID = types.StringValue(connectivityRule.GetId())
+	model.AzurePeResourceID = types.StringNull()
 
 	if connectivityRule.Spec.GetPrivateRule() != nil {
 		model.ConnectivityType = types.StringValue(connectivityRuleTypePrivate)
@@ -378,18 +379,14 @@ func updateConnectivityRuleModelFromSpec(model *connectivityRuleResourceModel, c
 		}
 
 		// Only set azure_pe_resource_id if it's not empty, otherwise keep it as null
-		azurePeResourceId := connectivityRule.Spec.GetPrivateRule().GetAzurePeResourceId()
-		if azurePeResourceId != "" {
+		if azurePeResourceId := connectivityRule.Spec.GetPrivateRule().GetAzurePeResourceId(); azurePeResourceId != "" {
 			model.AzurePeResourceID = types.StringValue(azurePeResourceId)
-		} else {
-			model.AzurePeResourceID = types.StringNull()
 		}
 	} else if connectivityRule.Spec.GetPublicRule() != nil {
 		model.ConnectivityType = types.StringValue(connectivityRuleTypePublic)
 		model.ConnectionID = types.StringNull()
 		model.Region = types.StringNull()
 		model.GcpProjectID = types.StringNull()
-		model.AzurePeResourceID = types.StringNull()
 		model.EnableStableIps = types.BoolValue(connectivityRule.Spec.GetPublicRule().GetEnableStableIps())
 	} else {
 		diags.AddError("Invalid connectivity rule", "connectivity rule must be either public or private")

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -335,7 +335,7 @@ func getConnectivityRuleSpecFromModel(model *connectivityRuleResourceModel) (*co
 			return nil, diags
 		}
 
-		if isAzure && model.AzurePeResourceID.IsNull() {
+		if isAzure && (model.AzurePeResourceID.IsNull() || model.AzurePeResourceID.ValueString() == "") {
 			diags.AddError("Azure Private Endpoint Resource ID is required", "azure_pe_resource_id must be specified when region is azure")
 			return nil, diags
 		}

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -39,13 +39,14 @@ type (
 	}
 
 	connectivityRuleResourceModel struct {
-		ID               types.String   `tfsdk:"id"`
-		ConnectivityType types.String   `tfsdk:"connectivity_type"`
-		ConnectionID     types.String   `tfsdk:"connection_id"`
-		Region           types.String   `tfsdk:"region"`
-		GcpProjectID     types.String   `tfsdk:"gcp_project_id"`
-		EnableStableIps  types.Bool     `tfsdk:"enable_stable_ips"`
-		Timeouts         timeouts.Value `tfsdk:"timeouts"`
+		ID                types.String   `tfsdk:"id"`
+		ConnectivityType  types.String   `tfsdk:"connectivity_type"`
+		ConnectionID      types.String   `tfsdk:"connection_id"`
+		Region            types.String   `tfsdk:"region"`
+		GcpProjectID      types.String   `tfsdk:"gcp_project_id"`
+		AzurePeResourceID types.String   `tfsdk:"azure_pe_resource_id"`
+		EnableStableIps   types.Bool     `tfsdk:"enable_stable_ips"`
+		Timeouts          timeouts.Value `tfsdk:"timeouts"`
 	}
 )
 
@@ -103,15 +104,20 @@ func (r *connectivityRuleResource) Schema(ctx context.Context, _ resource.Schema
 				},
 			},
 			"connection_id": schema.StringAttribute{
-				Description: "The connection ID of the private connection.",
+				Description: "The connection ID of the private connection. Not applicable for Azure, where this is populated automatically after the Private Endpoint connection is approved.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"gcp_project_id": schema.StringAttribute{
-				Description: "The GCP project ID. Required when cloud_provider is 'gcp'.",
+				Description: "The GCP project ID. Required when region is 'gcp'.",
+				Optional:    true,
+			},
+			"azure_pe_resource_id": schema.StringAttribute{
+				Description: "The ARM resource ID of the customer's Azure Private Endpoint. Required when region is 'azure'. Example: '/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/privateEndpoints/{name}'.",
 				Optional:    true,
 			},
 			"region": schema.StringAttribute{
-				Description: "The region of the connection. Example: 'aws-us-west-2'.",
+				Description: "The region of the connection. Example: 'aws-us-west-2', 'gcp-us-central1', 'azure-centralus'.",
 				Optional:    true,
 			},
 			"enable_stable_ips": schema.BoolAttribute{
@@ -301,25 +307,44 @@ func getConnectivityRuleSpecFromModel(model *connectivityRuleResourceModel) (*co
 			diags.AddError("Invalid attribute for private connectivity rule", "enable_stable_ips can only be true when connectivity_type is 'public'")
 			return nil, diags
 		}
-		if model.ConnectionID.IsNull() {
-			diags.AddError("Connection ID is required", "connection_id must be specified when connectivity_type is 'private'")
-			return nil, diags
-		}
 
 		if model.Region.IsNull() {
 			diags.AddError("Region is required", "region must be specified when connectivity_type is 'private'")
 			return nil, diags
 		}
+		region := model.Region.ValueString()
+		isAzure := strings.HasPrefix(region, "azure")
 
-		if strings.HasPrefix(model.Region.ValueString(), "gcp") && model.GcpProjectID.IsNull() {
+		// connection_id is Optional+Computed (Azure populates it automatically), so an
+		// unconfigured value surfaces as Unknown rather than Null in the plan. Treat both
+		// as "not provided by the user".
+		connectionIDProvided := !model.ConnectionID.IsNull() && !model.ConnectionID.IsUnknown()
+
+		if !isAzure && !connectionIDProvided {
+			diags.AddError("Connection ID is required", "connection_id must be specified when connectivity_type is 'private'")
+			return nil, diags
+		}
+
+		if isAzure && connectionIDProvided {
+			diags.AddError("Invalid attribute for Azure connectivity rule", "connection_id must not be specified when region is azure; it is populated automatically after the Private Endpoint connection is approved")
+			return nil, diags
+		}
+
+		if strings.HasPrefix(region, "gcp") && model.GcpProjectID.IsNull() {
 			diags.AddError("GCP Project ID is required", "gcp_project_id must be specified when region is gcp")
 			return nil, diags
 		}
 
+		if isAzure && model.AzurePeResourceID.IsNull() {
+			diags.AddError("Azure Private Endpoint Resource ID is required", "azure_pe_resource_id must be specified when region is azure")
+			return nil, diags
+		}
+
 		privateRule := &connectivityrulev1.PrivateConnectivityRule{
-			ConnectionId: model.ConnectionID.ValueString(),
-			Region:       model.Region.ValueString(),
-			GcpProjectId: model.GcpProjectID.ValueString(),
+			ConnectionId:      model.ConnectionID.ValueString(),
+			Region:            region,
+			GcpProjectId:      model.GcpProjectID.ValueString(),
+			AzurePeResourceId: model.AzurePeResourceID.ValueString(),
 		}
 		return &connectivityrulev1.ConnectivityRuleSpec{
 			ConnectionType: &connectivityrulev1.ConnectivityRuleSpec_PrivateRule{
@@ -351,11 +376,20 @@ func updateConnectivityRuleModelFromSpec(model *connectivityRuleResourceModel, c
 		} else {
 			model.GcpProjectID = types.StringNull()
 		}
+
+		// Only set azure_pe_resource_id if it's not empty, otherwise keep it as null
+		azurePeResourceId := connectivityRule.Spec.GetPrivateRule().GetAzurePeResourceId()
+		if azurePeResourceId != "" {
+			model.AzurePeResourceID = types.StringValue(azurePeResourceId)
+		} else {
+			model.AzurePeResourceID = types.StringNull()
+		}
 	} else if connectivityRule.Spec.GetPublicRule() != nil {
 		model.ConnectivityType = types.StringValue(connectivityRuleTypePublic)
 		model.ConnectionID = types.StringNull()
 		model.Region = types.StringNull()
 		model.GcpProjectID = types.StringNull()
+		model.AzurePeResourceID = types.StringNull()
 		model.EnableStableIps = types.BoolValue(connectivityRule.Spec.GetPublicRule().GetEnableStableIps())
 	} else {
 		diags.AddError("Invalid connectivity rule", "connectivity rule must be either public or private")

--- a/internal/provider/connectivity_rule_resource_test.go
+++ b/internal/provider/connectivity_rule_resource_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -126,6 +128,44 @@ func TestAccConnectivityRuleResource_AWS_Private(t *testing.T) {
 	})
 }
 
+func TestAccConnectivityRuleResource_Azure_Private(t *testing.T) {
+	subscriptionID := os.Getenv("INTEGRATION_TEST_AZURE_SUBSCRIPTION_ID")
+	azurePeResourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/rg-saas-cicd-prod/providers/Microsoft.Network/privateEndpoints/temporal-pe", subscriptionID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if subscriptionID == "" {
+				t.Fatal("INTEGRATION_TEST_AZURE_SUBSCRIPTION_ID must be set for Azure connectivity rule tests")
+			}
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConnectivityRuleResourceConfig_AzurePrivate(azurePeResourceID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("temporalcloud_connectivity_rule.test_azure_private", "connectivity_type", "private"),
+					resource.TestCheckResourceAttr("temporalcloud_connectivity_rule.test_azure_private", "region", "azure-centralus"),
+					resource.TestCheckResourceAttr("temporalcloud_connectivity_rule.test_azure_private", "azure_pe_resource_id", azurePeResourceID),
+				),
+			},
+			// Import state testing
+			{
+				ResourceName:      "temporalcloud_connectivity_rule.test_azure_private",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete the private connectivity rule
+			{
+				ResourceName:      "temporalcloud_connectivity_rule.test_azure_private",
+				ImportState:       true,
+				ImportStateVerify: true,
+				Destroy:           true,
+			},
+		},
+	})
+}
+
 func TestAccConnectivityRuleResource_ValidationErrors(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -157,6 +197,16 @@ func TestAccConnectivityRuleResource_ValidationErrors(t *testing.T) {
 				Config: testAccConnectivityRuleResourceConfig_PrivateWithStableIps(),
 				// Should fail because enable_stable_ips is only valid for public rules
 				ExpectError: regexp.MustCompile("enable_stable_ips can only be true when connectivity_type is 'public'"),
+			},
+			{
+				Config: testAccConnectivityRuleResourceConfig_PrivateWithoutAzurePeResourceId(),
+				// Should fail at plan time due to missing required attribute
+				ExpectError: regexp.MustCompile("Azure Private Endpoint Resource ID is required"),
+			},
+			{
+				Config: testAccConnectivityRuleResourceConfig_AzureWithConnectionId(),
+				// Should fail because connection_id is populated automatically for Azure
+				ExpectError: regexp.MustCompile("connection_id must not be specified when region is azure"),
 			},
 		},
 	})
@@ -213,6 +263,48 @@ resource "temporalcloud_connectivity_rule" "test_aws_private" {
   connectivity_type = "private"
   connection_id     = "vpce-testconnid"
   region           = "aws-us-west-2"
+}
+`
+}
+
+func testAccConnectivityRuleResourceConfig_AzurePrivate(azurePeResourceID string) string {
+	return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_connectivity_rule" "test_azure_private" {
+  connectivity_type    = "private"
+  region               = "azure-centralus"
+  azure_pe_resource_id = %[1]q
+}
+`, azurePeResourceID)
+}
+
+func testAccConnectivityRuleResourceConfig_PrivateWithoutAzurePeResourceId() string {
+	return `
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_connectivity_rule" "test" {
+  connectivity_type = "private"
+  region            = "azure-centralus"
+}
+`
+}
+
+func testAccConnectivityRuleResourceConfig_AzureWithConnectionId() string {
+	return `
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_connectivity_rule" "test" {
+  connectivity_type    = "private"
+  region               = "azure-centralus"
+  connection_id        = "should-not-be-set"
+  azure_pe_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-saas-cicd-prod/providers/Microsoft.Network/privateEndpoints/temporal-pe"
 }
 `
 }

--- a/internal/provider/validators/region_validator.go
+++ b/internal/provider/validators/region_validator.go
@@ -21,11 +21,11 @@ func RegionFormat() validator.String {
 }
 
 func (v *regionFormatValidator) Description(ctx context.Context) string {
-	return "must be a valid Temporal Cloud region format (e.g., aws-us-east-1, gcp-us-central1, azure-eastus)"
+	return "must be a valid Temporal Cloud region format (e.g., aws-us-east-1, gcp-us-central1, azure-centralus)"
 }
 
 func (v *regionFormatValidator) MarkdownDescription(ctx context.Context) string {
-	return "must be a valid Temporal Cloud region format (e.g., `aws-us-east-1`, `gcp-us-central1`, `azure-eastus`). See [available regions](https://docs.temporal.io/cloud/regions)."
+	return "must be a valid Temporal Cloud region format (e.g., `aws-us-east-1`, `gcp-us-central1`, `azure-centralus`). See [available regions](https://docs.temporal.io/cloud/regions)."
 }
 
 func (v *regionFormatValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
@@ -39,7 +39,7 @@ func (v *regionFormatValidator) ValidateString(ctx context.Context, req validato
 		resp.Diagnostics.AddAttributeError(
 			req.Path,
 			"Invalid Region Format",
-			fmt.Sprintf("Region %q does not match expected format. Regions must be prefixed with cloud provider (e.g., aws-us-east-1, gcp-us-central1, azure-eastus). See https://docs.temporal.io/cloud/regions", value),
+			fmt.Sprintf("Region %q does not match expected format. Regions must be prefixed with cloud provider (e.g., aws-us-east-1, gcp-us-central1, azure-centralus). See https://docs.temporal.io/cloud/regions", value),
 		)
 	}
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
adds azure support for connectivity rules
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes private connectivity validation and API mapping for all providers via `connection_id` optional/computed; misconfiguration could break AWS/GCP plans, while Azure rules depend on correct PE IDs and live integration tests.
> 
> **Overview**
> Adds **Azure private connectivity** to `temporalcloud_connectivity_rule` and its data source via a new optional **`azure_pe_resource_id`** (ARM Private Endpoint ID) for regions prefixed with `azure`.
> 
> **Azure-specific behavior:** `connection_id` is now **optional + computed**—required for AWS/GCP private rules, forbidden on create for Azure (filled in after PE approval). Plan-time validation enforces `azure_pe_resource_id` for Azure regions and blocks user-supplied `connection_id` there.
> 
> Bumps **`go.temporal.io/cloud-sdk`** to v0.15.0, updates docs/examples and region validator examples (`azure-centralus`), and wires **`INTEGRATION_TEST_AZURE_SUBSCRIPTION_ID`** into CI with new Azure acceptance tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a464e616bde5c162f8095fc42da22a29a463e5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->