### PR TITLE
[CLDIAM-1240][bug] fix silent removal of project roles

### DIFF
--- a/internal/provider/access.go
+++ b/internal/provider/access.go
@@ -174,6 +174,24 @@ func getAccountAccessFromModel(ctx context.Context, accountAccess string, accoun
 	}, diags
 }
 
+// preserveProjectAccesses copies project access grants from the Access currently stored server-side
+// onto a freshly built Access.
+//
+// Terraform does not manage project accesses yet, so rebuilding a spec from configuration alone
+// sends a nil ProjectAccesses map. The server declares an API version at or above the
+// min_version of Access.project_accesses, so it treats the caller as project-aware and reads that
+// nil map as "revoke every grant" rather than "field not supported by this client". Without this,
+// an unrelated edit (even just a description change) silently revokes grants made outside
+// Terraform.
+//
+// Remove this once project accesses are a managed attribute and configuration is authoritative.
+func preserveProjectAccesses(built *identityv1.Access, current *identityv1.Access) {
+	if built == nil {
+		return
+	}
+	built.ProjectAccesses = current.GetProjectAccesses()
+}
+
 func getNamespaceSetFromSpec(ctx context.Context, spec *identityv1.Access) (types.Set, diag.Diagnostics) {
 	var diags diag.Diagnostics
 

--- a/internal/provider/access_test.go
+++ b/internal/provider/access_test.go
@@ -125,3 +125,60 @@ func TestGetAccountAccessFromModel(t *testing.T) {
 		})
 	}
 }
+
+func TestPreserveProjectAccesses(t *testing.T) {
+	t.Parallel()
+
+	grants := map[string]*identityv1.ProjectAccess{
+		"project-abc": {Role: identityv1.ProjectAccess_PROJECT_ROLE_ADMIN},
+	}
+
+	t.Run("carries grants onto a freshly built access", func(t *testing.T) {
+		t.Parallel()
+
+		built := &identityv1.Access{AccountAccess: &identityv1.AccountAccess{Role: identityv1.AccountAccess_ROLE_READ}}
+		current := &identityv1.Access{ProjectAccesses: grants}
+
+		preserveProjectAccesses(built, current)
+
+		if len(built.GetProjectAccesses()) != 1 {
+			t.Fatalf("expected 1 preserved grant, got %d", len(built.GetProjectAccesses()))
+		}
+		if got := built.GetProjectAccesses()["project-abc"].GetRole(); got != identityv1.ProjectAccess_PROJECT_ROLE_ADMIN {
+			t.Errorf("expected admin role, got %v", got)
+		}
+		// Preserving must not disturb the access the caller built from configuration.
+		if built.GetAccountAccess().GetRole() != identityv1.AccountAccess_ROLE_READ {
+			t.Error("account access was modified")
+		}
+	})
+
+	t.Run("no grants server-side leaves the built access alone", func(t *testing.T) {
+		t.Parallel()
+
+		built := &identityv1.Access{}
+		preserveProjectAccesses(built, &identityv1.Access{})
+
+		if built.GetProjectAccesses() != nil {
+			t.Errorf("expected nil, got %v", built.GetProjectAccesses())
+		}
+	})
+
+	t.Run("nil current access is tolerated", func(t *testing.T) {
+		t.Parallel()
+
+		built := &identityv1.Access{}
+		preserveProjectAccesses(built, nil)
+
+		if built.GetProjectAccesses() != nil {
+			t.Errorf("expected nil, got %v", built.GetProjectAccesses())
+		}
+	})
+
+	// A namespace-scoped service account has no Access message at all.
+	t.Run("nil built access does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		preserveProjectAccesses(nil, &identityv1.Access{ProjectAccesses: grants})
+	})
+}

--- a/internal/provider/group_access_resource.go
+++ b/internal/provider/group_access_resource.go
@@ -143,6 +143,8 @@ func (r *groupAccessResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Use the current group spec to update the access.
 	spec := currentGroup.GetGroup().GetSpec()
+	// Read before spec.Access is overwritten below.
+	preserveProjectAccesses(access, spec.GetAccess())
 	spec.Access = access
 	svcResp, err := r.client.CloudService().UpdateUserGroup(ctx, &cloudservicev1.UpdateUserGroupRequest{
 		GroupId:          plan.ID.ValueString(),
@@ -246,6 +248,8 @@ func (r *groupAccessResource) Update(ctx context.Context, req resource.UpdateReq
 
 	// Use the current group spec to update the access.
 	spec := currentGroup.GetGroup().GetSpec()
+	// Read before spec.Access is overwritten below.
+	preserveProjectAccesses(access, spec.GetAccess())
 	spec.Access = access
 	svcResp, err := r.client.CloudService().UpdateUserGroup(ctx, &cloudservicev1.UpdateUserGroupRequest{
 		GroupId:          plan.ID.ValueString(),
@@ -313,6 +317,9 @@ func (r *groupAccessResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	// Use the current group spec to update the access
 	spec := currentGroup.GetGroup().GetSpec()
+	// This resource only manages account and namespace access, so removing it must not take the
+	// group's project grants with it. Read before spec.Access is overwritten below.
+	preserveProjectAccesses(access, spec.GetAccess())
 	spec.Access = access
 
 	svcResp, err := r.client.CloudService().UpdateUserGroup(ctx, &cloudservicev1.UpdateUserGroupRequest{

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -314,6 +314,7 @@ func (r *serviceAccountResource) Update(ctx context.Context, req resource.Update
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	preserveProjectAccesses(spec.GetAccess(), currentServiceAccount.GetServiceAccount().GetSpec().GetAccess())
 
 	svcResp, err := r.client.CloudService().UpdateServiceAccount(ctx, &cloudservicev1.UpdateServiceAccountRequest{
 		ServiceAccountId: plan.ID.ValueString(),

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -248,6 +248,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		AccountAccess:     accountAccess,
 		NamespaceAccesses: namespaceAccesses,
 	}
+	preserveProjectAccesses(access, currentUser.GetUser().GetSpec().GetAccess())
 
 	svcResp, err := r.client.CloudService().UpdateUser(ctx, &cloudservicev1.UpdateUserRequest{
 		UserId: plan.ID.ValueString(),


### PR DESCRIPTION
## Summary

Updating a user, user group, or service account through Terraform silently revokes any
Temporal Cloud **project access grants** made outside Terraform. This preserves them.

## Root cause

All three identity resources rebuild `identityv1.Access` from configuration on every write,
setting only `AccountAccess` and `NamespaceAccesses`. `ProjectAccesses` is never set, so the
spec goes out with a nil map.

That nil map used to be harmless. `Access.project_accesses` carries `min_version=v0.18.0`, and
below that boundary the server knows the client cannot express the field and preserves the
grants. Since `v1.7.0` of Terraform, we bundle cloud-sdk `v0.16.0`, which declares API version `v0.19.1` in the
`temporal-cloud-api-version` header — so the server now treats the provider as project-aware
and reads the nil map as "revoke everything."

Net effect on v1.7.0: changing a service account's *description* is enough to drop every
project grant it had.

## Change

New `preserveProjectAccesses` helper in `access.go`, applied wherever an `Access` is rebuilt
against an object that already exists:

- `service_account_resource.go` — Update
- `user_resource.go` — Update
- `group_access_resource.go` — Create, Update, Delete

All of these already fetched the current object for its `ResourceVersion`, so there are no new
API calls. Creates of brand-new objects are untouched — nothing to preserve.

`group_access` Delete preserves as well: that resource manages account and namespace access
only, so removing it should not take the group's project grants with it.


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes identity/IAM update payloads across multiple resources; incorrect preservation logic could leave stale grants or still drop access, but the change is narrowly scoped to copying existing server-side project grants.
> 
> **Overview**
> Fixes a bug where **Terraform updates to users, groups, service accounts, or group access** could **silently revoke project roles** assigned outside Terraform (e.g. in the UI).
> 
> Because project access is not a managed attribute yet, update paths rebuild `identityv1.Access` from config with a **nil** `ProjectAccesses` map. The API treats that as “clear all project grants” for project-aware clients. The PR adds **`preserveProjectAccesses`**, which copies `ProjectAccesses` from the current server spec onto the outgoing access before create/update/delete on **`temporalcloud_user`**, **`temporalcloud_service_account`**, and **`temporalcloud_group_access`** (including group access delete so removing Terraform-managed account/namespace access does not strip project grants). Unit tests cover preservation, empty/nil server state, and nil built access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571dacd9dabb1d7d51b20015e7251f0172541f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->