### PR TITLE
Add project_accesses to group access

### DIFF
--- a/docs/resources/group_access.md
+++ b/docs/resources/group_access.md
@@ -29,6 +29,10 @@ data "temporalcloud_scim_group" "my_scim_group" {
   idp_id = "usually-group-name"
 }
 
+resource "temporalcloud_project" "payments" {
+  display_name = "payments"
+}
+
 resource "temporalcloud_namespace" "test" {
   name         = "my-namespace"
   regions      = ["aws-us-east-1"]
@@ -47,6 +51,12 @@ resource "temporalcloud_group_access" "my_group_access" {
       permission   = "write"
     }
   ]
+  project_accesses = [
+    {
+      project_id = temporalcloud_project.payments.id
+      role       = "read"
+    }
+  ]
 }
 ```
 
@@ -62,6 +72,7 @@ resource "temporalcloud_group_access" "my_group_access" {
 
 - `account_access_custom_roles` (Set of String) The set of custom role IDs assigned within account_access in addition to the built-in account_access role. Empty sets are not allowed, omit the attribute instead.
 - `namespace_accesses` (Attributes Set) The set of namespace accesses. Empty sets are not allowed, omit the attribute instead. Users with account_access roles of owner or admin cannot be assigned explicit permissions to namespaces. They implicitly receive access to all Namespaces. (see [below for nested schema](#nestedatt--namespace_accesses))
+- `project_accesses` (Attributes Set) The set of project accesses. Empty sets are not allowed, omit the attribute instead. Cannot be set when account_access is owner or admin, which implicitly receive access to all Projects. (see [below for nested schema](#nestedatt--project_accesses))
 
 <a id="nestedatt--namespace_accesses"></a>
 ### Nested Schema for `namespace_accesses`
@@ -70,3 +81,12 @@ Required:
 
 - `namespace_id` (String) The namespace to assign permissions to.
 - `permission` (String) The permission to assign. Must be one of admin, write, or read (case-insensitive)
+
+
+<a id="nestedatt--project_accesses"></a>
+### Nested Schema for `project_accesses`
+
+Required:
+
+- `project_id` (String) The project the role applies to.
+- `role` (String) The role to assign. Must be one of `admin`, `write`, `read`, `list`, `contribute`, or `member` (case-insensitive).

--- a/examples/resources/temporalcloud_group_access/resource.tf
+++ b/examples/resources/temporalcloud_group_access/resource.tf
@@ -14,6 +14,10 @@ data "temporalcloud_scim_group" "my_scim_group" {
   idp_id = "usually-group-name"
 }
 
+resource "temporalcloud_project" "payments" {
+  display_name = "payments"
+}
+
 resource "temporalcloud_namespace" "test" {
   name         = "my-namespace"
   regions      = ["aws-us-east-1"]
@@ -30,6 +34,12 @@ resource "temporalcloud_group_access" "my_group_access" {
     {
       namespace_id = temporalcloud_namespace.test.id
       permission   = "write"
+    }
+  ]
+  project_accesses = [
+    {
+      project_id = temporalcloud_project.payments.id
+      role       = "read"
     }
   ]
 }

--- a/internal/provider/access.go
+++ b/internal/provider/access.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -150,6 +152,7 @@ func addAccessSchemaAttrs(s *schema.Schema, accountDescriptionSuffix string) {
 		},
 	}
 
+	s.Attributes["project_accesses"] = projectAccessesSchema("")
 }
 
 func projectAccessesManagedByConfig(configAccesses types.Set) bool {
@@ -190,6 +193,97 @@ func projectAccessRevocationWarning(stateAccesses types.Set, configAccesses type
 	)
 
 	return diags
+}
+
+// projectAccessRevocationOnCreateWarning warns that taking over a group's access revokes the
+// project roles it already holds and configuration does not name.
+//
+// projectAccessRevocationWarning cannot report this: a create has no prior state to compare
+// against, so the roles have to be read from the API. It only arises for group access, which
+// "creates" by overwriting the access of a group that already exists, so out-of-band roles are lost
+// the first time the group is brought under Terraform management. Users and service accounts are
+// created fresh and have no roles to lose.
+//
+// Unlike the update path, this compares project IDs rather than asking whether configuration
+// manages the attribute at all. An update renders the roles it omits as removals in the plan diff,
+// so a configuration that names some of them already shows which ones it drops. A create has no
+// prior state to diff against, so the plan shows only the roles being added and the ones being
+// overwritten appear nowhere.
+func projectAccessRevocationOnCreateWarning(ctx context.Context, currentAccesses map[string]*identityv1.ProjectAccess, configAccesses types.Set) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if len(currentAccesses) == 0 {
+		return diags
+	}
+
+	configured, known, d := projectIDsFromSet(ctx, configAccesses)
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// A project ID that is not known until apply cannot be matched against the ones the group
+	// holds, and configuration that names it is managing the role, so assume nothing is lost.
+	if !known {
+		return diags
+	}
+
+	revoked := make([]string, 0, len(currentAccesses))
+	for projectID := range currentAccesses {
+		if _, ok := configured[projectID]; !ok {
+			revoked = append(revoked, projectID)
+		}
+	}
+	if len(revoked) == 0 {
+		return diags
+	}
+
+	sort.Strings(revoked)
+
+	diags.AddAttributeWarning(
+		path.Root("project_accesses"),
+		"Project roles will be revoked",
+		fmt.Sprintf("This group holds %d project role(s) that are not in the configuration and will be revoked by this apply: %s. "+
+			"Bringing a group under management has no prior state, so these do not appear in the plan. "+
+			"Add them to project_accesses to keep them.",
+			len(revoked), strings.Join(revoked, ", ")),
+	)
+
+	return diags
+}
+
+// projectIDsFromSet collects the project IDs a configured set names.
+// The bool reports whether every ID was known.
+func projectIDsFromSet(ctx context.Context, set types.Set) (map[string]struct{}, bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if set.IsNull() {
+		return nil, true, diags
+	}
+	if set.IsUnknown() {
+		return nil, false, diags
+	}
+
+	elements := make([]types.Object, 0, len(set.Elements()))
+	diags.Append(set.ElementsAs(ctx, &elements, false)...)
+	if diags.HasError() {
+		return nil, false, diags
+	}
+
+	projectIDs := make(map[string]struct{}, len(elements))
+	for _, element := range elements {
+		var model projectAccessModel
+		diags.Append(element.As(ctx, &model, basetypes.ObjectAsOptions{})...)
+		if diags.HasError() {
+			return nil, false, diags
+		}
+		if model.ProjectID.IsUnknown() {
+			return nil, false, diags
+		}
+		projectIDs[model.ProjectID.ValueString()] = struct{}{}
+	}
+
+	return projectIDs, true, diags
 }
 
 func getProjectAccessesFromSet(ctx context.Context, set types.Set) (map[string]*identityv1.ProjectAccess, diag.Diagnostics) {
@@ -353,25 +447,6 @@ func getAccountAccessFromModel(ctx context.Context, accountAccess string, accoun
 		Role:        role,
 		CustomRoles: accountAccessCustomRoles,
 	}, diags
-}
-
-// preserveProjectAccesses copies project access grants from the Access currently stored server-side
-// onto a freshly built Access.
-//
-// Group access does not manage project accesses yet, so rebuilding a spec from configuration alone
-// sends a nil ProjectAccesses map. The server declares an API version at or above the
-// min_version of Access.project_accesses, so it treats the caller as project-aware and reads that
-// nil map as "revoke every grant" rather than "field not supported by this client". Without this,
-// an unrelated edit (even just a description change) silently revokes grants made outside
-// Terraform.
-//
-// Remove this once group access manages project_accesses too. Users and service accounts already
-// do, and build their spec from configuration alone.
-func preserveProjectAccesses(built *identityv1.Access, current *identityv1.Access) {
-	if built == nil {
-		return
-	}
-	built.ProjectAccesses = current.GetProjectAccesses()
 }
 
 func getNamespaceSetFromSpec(ctx context.Context, spec *identityv1.Access) (types.Set, diag.Diagnostics) {

--- a/internal/provider/access_test.go
+++ b/internal/provider/access_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -176,6 +178,90 @@ func boolToCount(b bool) int {
 	return 0
 }
 
+func TestProjectAccessRevocationOnCreateWarning(t *testing.T) {
+	t.Parallel()
+
+	held := func(projectIDs ...string) map[string]*identityv1.ProjectAccess {
+		accesses := make(map[string]*identityv1.ProjectAccess, len(projectIDs))
+		for _, projectID := range projectIDs {
+			accesses[projectID] = &identityv1.ProjectAccess{Role: identityv1.ProjectAccess_PROJECT_ROLE_READ}
+		}
+		return accesses
+	}
+	nullSet := types.SetNull(types.ObjectType{AttrTypes: projectAccessAttrs})
+	unknownSet := types.SetUnknown(types.ObjectType{AttrTypes: projectAccessAttrs})
+
+	cases := []struct {
+		name    string
+		current map[string]*identityv1.ProjectAccess
+		config  types.Set
+		// wantRevoked lists the project ids the warning must name. Empty means no warning at all.
+		wantRevoked []string
+	}{
+		{name: "group holds no roles", current: nil, config: nullSet},
+		{name: "group holds no roles and configuration adds some", current: nil, config: projectAccessSet("project-a")},
+		{name: "configuration names every role the group holds", current: held("project-a"), config: projectAccessSet("project-a")},
+		// A create has no prior state, so an omitted role appears nowhere in the plan. Unlike the
+		// update path, configuration naming some roles is not enough to stay quiet.
+		{name: "configuration replaces the roles", current: held("project-a"), config: projectAccessSet("project-b"), wantRevoked: []string{"project-a"}},
+		{name: "configuration names only some of the roles", current: held("project-a", "project-b"), config: projectAccessSet("project-a"), wantRevoked: []string{"project-b"}},
+		{name: "configuration omits the group's roles", current: held("project-a", "project-b"), config: nullSet, wantRevoked: []string{"project-a", "project-b"}},
+		// Ids that arrive at apply time cannot be matched against the ones the group holds.
+		{name: "configuration is not known until apply", current: held("project-a"), config: unknownSet},
+		{name: "a project id is not known until apply", current: held("project-a"), config: projectAccessSetWithUnknownID()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := projectAccessRevocationOnCreateWarning(context.Background(), tc.current, tc.config)
+
+			if diags.HasError() {
+				t.Fatalf("expected no errors, got %+v", diags)
+			}
+
+			warnings := diags.Warnings()
+			if len(tc.wantRevoked) == 0 {
+				if len(warnings) != 0 {
+					t.Fatalf("expected no warnings, got %+v", warnings)
+				}
+				return
+			}
+			if len(warnings) != 1 {
+				t.Fatalf("expected 1 warning, got %d: %+v", len(warnings), warnings)
+			}
+
+			// The plan shows nothing on create, so the message is the only place these ids appear.
+			detail := warnings[0].Detail()
+			for _, projectID := range tc.wantRevoked {
+				if !strings.Contains(detail, projectID) {
+					t.Errorf("warning does not name %q: %s", projectID, detail)
+				}
+			}
+			for projectID := range tc.current {
+				if slices.Contains(tc.wantRevoked, projectID) {
+					continue
+				}
+				if strings.Contains(detail, projectID) {
+					t.Errorf("warning names %q, which configuration keeps: %s", projectID, detail)
+				}
+			}
+		})
+	}
+}
+
+// projectAccessSetWithUnknownID builds the shape a plan carries when project_id references a
+// project that is created by the same apply.
+func projectAccessSetWithUnknownID() types.Set {
+	return types.SetValueMust(types.ObjectType{AttrTypes: projectAccessAttrs}, []attr.Value{
+		types.ObjectValueMust(projectAccessAttrs, map[string]attr.Value{
+			"project_id": types.StringUnknown(),
+			"role":       internaltypes.CaseInsensitiveString("read"),
+		}),
+	})
+}
+
 func projectAccessSet(projectIDs ...string) types.Set {
 	objects := make([]attr.Value, 0, len(projectIDs))
 	for _, projectID := range projectIDs {
@@ -186,61 +272,4 @@ func projectAccessSet(projectIDs ...string) types.Set {
 	}
 
 	return types.SetValueMust(types.ObjectType{AttrTypes: projectAccessAttrs}, objects)
-}
-
-func TestPreserveProjectAccesses(t *testing.T) {
-	t.Parallel()
-
-	grants := map[string]*identityv1.ProjectAccess{
-		"project-abc": {Role: identityv1.ProjectAccess_PROJECT_ROLE_ADMIN},
-	}
-
-	t.Run("carries grants onto a freshly built access", func(t *testing.T) {
-		t.Parallel()
-
-		built := &identityv1.Access{AccountAccess: &identityv1.AccountAccess{Role: identityv1.AccountAccess_ROLE_READ}}
-		current := &identityv1.Access{ProjectAccesses: grants}
-
-		preserveProjectAccesses(built, current)
-
-		if len(built.GetProjectAccesses()) != 1 {
-			t.Fatalf("expected 1 preserved grant, got %d", len(built.GetProjectAccesses()))
-		}
-		if got := built.GetProjectAccesses()["project-abc"].GetRole(); got != identityv1.ProjectAccess_PROJECT_ROLE_ADMIN {
-			t.Errorf("expected admin role, got %v", got)
-		}
-		// Preserving must not disturb the access the caller built from configuration.
-		if built.GetAccountAccess().GetRole() != identityv1.AccountAccess_ROLE_READ {
-			t.Error("account access was modified")
-		}
-	})
-
-	t.Run("no grants server-side leaves the built access alone", func(t *testing.T) {
-		t.Parallel()
-
-		built := &identityv1.Access{}
-		preserveProjectAccesses(built, &identityv1.Access{})
-
-		if built.GetProjectAccesses() != nil {
-			t.Errorf("expected nil, got %v", built.GetProjectAccesses())
-		}
-	})
-
-	t.Run("nil current access is tolerated", func(t *testing.T) {
-		t.Parallel()
-
-		built := &identityv1.Access{}
-		preserveProjectAccesses(built, nil)
-
-		if built.GetProjectAccesses() != nil {
-			t.Errorf("expected nil, got %v", built.GetProjectAccesses())
-		}
-	})
-
-	// A namespace-scoped service account has no Access message at all.
-	t.Run("nil built access does not panic", func(t *testing.T) {
-		t.Parallel()
-
-		preserveProjectAccesses(nil, &identityv1.Access{ProjectAccesses: grants})
-	})
 }

--- a/internal/provider/group_access_resource.go
+++ b/internal/provider/group_access_resource.go
@@ -57,12 +57,14 @@ type groupAccessResourceModel struct {
 	AccountAccess            internaltypes.CaseInsensitiveStringValue `tfsdk:"account_access"`
 	AccountAccessCustomRoles types.Set                                `tfsdk:"account_access_custom_roles"`
 	NamespaceAccesses        types.Set                                `tfsdk:"namespace_accesses"`
+	ProjectAccesses          types.Set                                `tfsdk:"project_accesses"`
 }
 
 var (
 	_ resource.Resource                = (*groupAccessResource)(nil)
 	_ resource.ResourceWithConfigure   = (*groupAccessResource)(nil)
 	_ resource.ResourceWithImportState = (*groupAccessResource)(nil)
+	_ resource.ResourceWithModifyPlan  = (*groupAccessResource)(nil)
 )
 
 func NewGroupAccessResource() resource.Resource {
@@ -89,6 +91,64 @@ func (r *groupAccessResource) Configure(_ context.Context, req resource.Configur
 
 func (r *groupAccessResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_group_access"
+}
+
+// ModifyPlan warns when an apply would revoke project roles that configuration does not list.
+func (r *groupAccessResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Destroying this resource is a request to remove the group's access, so losing its project
+	// roles is the point rather than a surprise.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var config groupAccessResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Bringing a group under management overwrites the access it already has, and a create has no
+	// prior state to compare against, so read the group's roles to report them before the apply.
+	if req.State.Raw.IsNull() {
+		resp.Diagnostics.Append(r.warnProjectAccessRevocationOnCreate(ctx, config)...)
+		return
+	}
+
+	var state groupAccessResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(projectAccessRevocationWarning(state.ProjectAccesses, config.ProjectAccesses)...)
+}
+
+// warnProjectAccessRevocationOnCreate reads the group's current project roles so that a plan can
+// report the ones configuration omits.
+//
+// The read is best effort: an unconfigured client, an ID that is not known until apply, or a group
+// that cannot be fetched skips the warning, and nothing reports it later. That is not a silent
+// revocation, because Create fetches the same group before overwriting its access, so a read that
+// keeps failing fails the apply instead.
+func (r *groupAccessResource) warnProjectAccessRevocationOnCreate(ctx context.Context, config groupAccessResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if r.client == nil || config.ID.IsNull() || config.ID.IsUnknown() {
+		return diags
+	}
+
+	currentGroup, err := r.client.CloudService().GetUserGroup(ctx, &cloudservicev1.GetUserGroupRequest{
+		GroupId: config.ID.ValueString(),
+	})
+	if err != nil {
+		return diags
+	}
+
+	return projectAccessRevocationOnCreateWarning(
+		ctx,
+		currentGroup.GetGroup().GetSpec().GetAccess().GetProjectAccesses(),
+		config.ProjectAccesses,
+	)
 }
 
 func (r *groupAccessResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -136,15 +196,20 @@ func (r *groupAccessResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	projectAccesses, d := getProjectAccessesFromSet(ctx, plan.ProjectAccesses)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	access := &identityv1.Access{
 		AccountAccess:     accountAccess,
 		NamespaceAccesses: namespaceAccesses,
+		ProjectAccesses:   projectAccesses,
 	}
 
 	// Use the current group spec to update the access.
 	spec := currentGroup.GetGroup().GetSpec()
-	// Read before spec.Access is overwritten below.
-	preserveProjectAccesses(access, spec.GetAccess())
 	spec.Access = access
 	svcResp, err := r.client.CloudService().UpdateUserGroup(ctx, &cloudservicev1.UpdateUserGroupRequest{
 		GroupId:          plan.ID.ValueString(),
@@ -241,15 +306,20 @@ func (r *groupAccessResource) Update(ctx context.Context, req resource.UpdateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	projectAccesses, d := getProjectAccessesFromSet(ctx, plan.ProjectAccesses)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	access := &identityv1.Access{
 		AccountAccess:     accountAccess,
 		NamespaceAccesses: namespaceAccesses,
+		ProjectAccesses:   projectAccesses,
 	}
 
 	// Use the current group spec to update the access.
 	spec := currentGroup.GetGroup().GetSpec()
-	// Read before spec.Access is overwritten below.
-	preserveProjectAccesses(access, spec.GetAccess())
 	spec.Access = access
 	svcResp, err := r.client.CloudService().UpdateUserGroup(ctx, &cloudservicev1.UpdateUserGroupRequest{
 		GroupId:          plan.ID.ValueString(),
@@ -313,13 +383,11 @@ func (r *groupAccessResource) Delete(ctx context.Context, req resource.DeleteReq
 	access := &identityv1.Access{
 		AccountAccess:     nil,
 		NamespaceAccesses: map[string]*identityv1.NamespaceAccess{},
+		ProjectAccesses:   map[string]*identityv1.ProjectAccess{},
 	}
 
 	// Use the current group spec to update the access
 	spec := currentGroup.GetGroup().GetSpec()
-	// This resource only manages account and namespace access, so removing it must not take the
-	// group's project grants with it. Read before spec.Access is overwritten below.
-	preserveProjectAccesses(access, spec.GetAccess())
 	spec.Access = access
 
 	svcResp, err := r.client.CloudService().UpdateUserGroup(ctx, &cloudservicev1.UpdateUserGroupRequest{
@@ -371,6 +439,13 @@ func updateGroupAccessModel(ctx context.Context, state *groupAccessResourceModel
 		return diags
 	}
 	state.AccountAccessCustomRoles = accountAccessCustomRoles
+
+	projectAccesses, d := getProjectSetFromSpec(ctx, group.GetSpec().GetAccess())
+	diags.Append(d...)
+	if diags.HasError() {
+		return diags
+	}
+	state.ProjectAccesses = projectAccesses
 
 	namespaceAccesses, d := getNamespaceSetFromSpec(ctx, group.GetSpec().GetAccess())
 	diags.Append(d...)

--- a/internal/provider/group_access_resource_test.go
+++ b/internal/provider/group_access_resource_test.go
@@ -225,3 +225,80 @@ resource "temporalcloud_group_access" "terraform" {
 		},
 	})
 }
+
+func TestAccGroupAccess_WithProjectAccesses(t *testing.T) {
+	type configArgs struct {
+		ProjectName     string
+		ProjectAccesses string
+	}
+
+	projectName := createRandomName()
+
+	tmpl := template.Must(template.New("config").Parse(`
+provider "temporalcloud" {
+}
+
+data "temporalcloud_scim_group" "terraform" {
+  idp_id = "tf-basic-scim-group"
+}
+
+resource "temporalcloud_project" "test" {
+  display_name = "{{ .ProjectName }}"
+}
+
+resource "temporalcloud_group_access" "terraform" {
+  id             = data.temporalcloud_scim_group.terraform.id
+  account_access = "read"
+  {{ .ProjectAccesses }}
+}`))
+
+	config := func(args configArgs) string {
+		var buf bytes.Buffer
+		writer := bufio.NewWriter(&buf)
+		if err := tmpl.Execute(writer, args); err != nil {
+			t.Errorf("failed to execute template: %v", err)
+			t.FailNow()
+		}
+		writer.Flush()
+		return buf.String()
+	}
+
+	withRole := func(role string) string {
+		return fmt.Sprintf(`project_accesses = [
+    {
+      project_id = temporalcloud_project.test.id
+      role       = "%s"
+    }
+  ]`, role)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config(configArgs{ProjectName: projectName, ProjectAccesses: withRole("read")}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("temporalcloud_group_access.terraform", "project_accesses.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("temporalcloud_group_access.terraform", "project_accesses.*", map[string]string{
+						"role": "read",
+					}),
+				),
+			},
+			{
+				Config: config(configArgs{ProjectName: projectName, ProjectAccesses: withRole("write")}),
+				Check: resource.TestCheckTypeSetElemNestedAttrs("temporalcloud_group_access.terraform", "project_accesses.*", map[string]string{
+					"role": "write",
+				}),
+			},
+			{
+				// Configuration is authoritative: dropping the attribute revokes the grant.
+				Config: config(configArgs{ProjectName: projectName, ProjectAccesses: ""}),
+				Check: resource.TestCheckNoResourceAttr(
+					"temporalcloud_group_access.terraform", "project_accesses.#"),
+			},
+		},
+	})
+}

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -138,7 +138,6 @@ func (r *userResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
 		},
 	}
 	addAccessSchemaAttrs(&s, " Users can only be set to `none` when they are managed by SCIM and derive their roles from group memberships.")
-	s.Attributes["project_accesses"] = projectAccessesSchema("")
 	resp.Schema = s
 }
 


### PR DESCRIPTION
Adds `project_access` to groups.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes IAM behavior for SCIM groups: first-time Terraform management or config drift can revoke existing project roles without appearing in the plan diff unless warnings are heeded.
> 
> **Overview**
> **`temporalcloud_group_access` can now declare per-project roles** via optional `project_accesses` (`project_id` + `role`), aligned with user access. Docs and examples show granting project read alongside namespace access.
> 
> Group create/update/delete **send project grants from configuration** instead of preserving existing API roles with `preserveProjectAccesses`, so Terraform is authoritative: omitted or removed `project_accesses` revokes roles on apply. **`ModifyPlan`** warns when roles in state (or, on first manage of an existing group, roles read from the API) are not listed in config, including project IDs on create where the plan would not show the drop.
> 
> Shared access schema wiring moves **`project_accesses` into `addAccessSchemaAttrs`** (duplicate attribute removed from the user resource schema). Acceptance and unit tests cover project access CRUD and revocation warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce44e7e274e51c177e310af1356662167f143a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->