### PR TITLE
Add project_id to connectivity rules

### DIFF
--- a/docs/data-sources/connectivity_rule.md
+++ b/docs/data-sources/connectivity_rule.md
@@ -27,5 +27,6 @@ Fetches details about a connectivity rule.
 - `created_at` (String) The time the connectivity rule was created.
 - `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule are reachable via a predictable set of public IPs. Only set for public connectivity rules.
 - `gcp_project_id` (String) The GCP project ID of the connectivity rule.
+- `project_id` (String) The ID of the Temporal Cloud project the connectivity rule belongs to.
 - `region` (String) The region of the connectivity rule.
 - `state` (String) The current state of the connectivity rule.

--- a/docs/resources/connectivity_rule.md
+++ b/docs/resources/connectivity_rule.md
@@ -95,7 +95,7 @@ resource "temporalcloud_namespace" "ns-with-cr" {
 - `connection_id` (String) The connection ID of the private connection. Not applicable for Azure, where this is populated automatically after the Private Endpoint connection is approved.
 - `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.
 - `gcp_project_id` (String) The GCP project ID. Required when region is 'gcp'.
-- `project_id` (String) The ID of the Temporal Cloud project this Connectivity Rule belongs to. Defaults to the account's default project. This rule can only be attached to namespaces in the same project. Cannot be changed after creation; the rule must be destroyed and recreated in the other project.
+- `project_id` (String) The ID of the Temporal Cloud project this Connectivity Rule belongs to. If not provided, the Connectivity Rule is created in the account's default project. This rule can only be attached to namespaces in the same project. Cannot be changed after creation; the rule must be destroyed and recreated in the other project.
 - `region` (String) The region of the connection. Example: 'aws-us-west-2', 'gcp-us-central1', 'azure-centralus'.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/connectivity_rule.md
+++ b/docs/resources/connectivity_rule.md
@@ -36,6 +36,18 @@ resource "temporalcloud_connectivity_rule" "public_rule_stable_ips" {
   enable_stable_ips = true
 }
 
+// Create Public Connectivity Rule in a specific project. Rules are created in the account's
+// default project unless project_id is set, and can only be attached to namespaces in the same
+// project as the rule.
+resource "temporalcloud_project" "payments" {
+  display_name = "payments"
+}
+
+resource "temporalcloud_connectivity_rule" "public_rule_in_project" {
+  connectivity_type = "public"
+  project_id        = temporalcloud_project.payments.id
+}
+
 // Create Private Connectivity Rule for AWS
 resource "temporalcloud_connectivity_rule" "private_aws" {
   connectivity_type = "private"
@@ -83,6 +95,7 @@ resource "temporalcloud_namespace" "ns-with-cr" {
 - `connection_id` (String) The connection ID of the private connection. Not applicable for Azure, where this is populated automatically after the Private Endpoint connection is approved.
 - `enable_stable_ips` (Boolean) If true, namespaces attached to this public connectivity rule will be reachable via a predictable set of public IPs. Only applies when connectivity_type is 'public'.
 - `gcp_project_id` (String) The GCP project ID. Required when region is 'gcp'.
+- `project_id` (String) The ID of the Temporal Cloud project this Connectivity Rule belongs to. Defaults to the account's default project. This rule can only be attached to namespaces in the same project. Cannot be changed after creation; the rule must be destroyed and recreated in the other project.
 - `region` (String) The region of the connection. Example: 'aws-us-west-2', 'gcp-us-central1', 'azure-centralus'.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/examples/resources/temporalcloud_connectivity_rule/resource.tf
+++ b/examples/resources/temporalcloud_connectivity_rule/resource.tf
@@ -21,6 +21,18 @@ resource "temporalcloud_connectivity_rule" "public_rule_stable_ips" {
   enable_stable_ips = true
 }
 
+// Create Public Connectivity Rule in a specific project. Rules are created in the account's
+// default project unless project_id is set, and can only be attached to namespaces in the same
+// project as the rule.
+resource "temporalcloud_project" "payments" {
+  display_name = "payments"
+}
+
+resource "temporalcloud_connectivity_rule" "public_rule_in_project" {
+  connectivity_type = "public"
+  project_id        = temporalcloud_project.payments.id
+}
+
 // Create Private Connectivity Rule for AWS
 resource "temporalcloud_connectivity_rule" "private_aws" {
   connectivity_type = "private"

--- a/internal/provider/connectivity_rule_datasource.go
+++ b/internal/provider/connectivity_rule_datasource.go
@@ -31,6 +31,7 @@ type (
 
 	connectivityRuleDataModel struct {
 		ID                types.String `tfsdk:"id"`
+		ProjectID         types.String `tfsdk:"project_id"`
 		ConnectivityType  types.String `tfsdk:"connectivity_type"`
 		ConnectionID      types.String `tfsdk:"connection_id"`
 		Region            types.String `tfsdk:"region"`
@@ -57,6 +58,10 @@ func connectivityRuleDataSourceSchema(idRequired bool) map[string]schema.Attribu
 
 	return map[string]schema.Attribute{
 		"id": idAttribute,
+		"project_id": schema.StringAttribute{
+			Computed:    true,
+			Description: "The ID of the Temporal Cloud project the connectivity rule belongs to.",
+		},
 		"connectivity_type": schema.StringAttribute{
 			Computed:    true,
 			Description: "The type of connectivity.",
@@ -162,6 +167,7 @@ func connectivityRuleToConnectivityRuleDataModel(connectivityRule *connectivityr
 
 	model := new(connectivityRuleDataModel)
 	model.ID = types.StringValue(connectivityRule.GetId())
+	model.ProjectID = types.StringValue(connectivityRule.GetProjectId())
 	model.State = types.StringValue(stateStr)
 	model.CreatedAt = types.StringValue(connectivityRule.GetCreatedTime().AsTime().Format(time.RFC3339))
 

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -95,7 +95,7 @@ func (r *connectivityRuleResource) Schema(ctx context.Context, _ resource.Schema
 				},
 			},
 			"project_id": schema.StringAttribute{
-				Description: "The ID of the Temporal Cloud project this Connectivity Rule belongs to. Defaults to the account's default project. This rule can only be attached to namespaces in the same project. Cannot be changed after creation; the rule must be destroyed and recreated in the other project.",
+				Description: "The ID of the Temporal Cloud project this Connectivity Rule belongs to. If not provided, the Connectivity Rule is created in the account's default project. This rule can only be attached to namespaces in the same project. Cannot be changed after creation; the rule must be destroyed and recreated in the other project.",
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -40,6 +40,7 @@ type (
 
 	connectivityRuleResourceModel struct {
 		ID                types.String   `tfsdk:"id"`
+		ProjectID         types.String   `tfsdk:"project_id"`
 		ConnectivityType  types.String   `tfsdk:"connectivity_type"`
 		ConnectionID      types.String   `tfsdk:"connection_id"`
 		Region            types.String   `tfsdk:"region"`
@@ -88,6 +89,14 @@ func (r *connectivityRuleResource) Schema(ctx context.Context, _ resource.Schema
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The unique identifier of the Connectivity Rule.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"project_id": schema.StringAttribute{
+				Description: "The ID of the Temporal Cloud project this Connectivity Rule belongs to. Defaults to the account's default project. This rule can only be attached to namespaces in the same project. Cannot be changed after creation; the rule must be destroyed and recreated in the other project.",
+				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -161,8 +170,11 @@ func (r *connectivityRuleResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	// project_id is Optional+Computed, so an unconfigured value is Unknown here and sends an empty
+	// string, which the API reads as the account's default project.
 	svcResp, err := r.client.CloudService().CreateConnectivityRule(ctx, &cloudservicev1.CreateConnectivityRuleRequest{
 		Spec:             spec,
+		ProjectId:        plan.ProjectID.ValueString(),
 		AsyncOperationId: uuid.New().String(),
 	})
 	if err != nil {
@@ -362,6 +374,8 @@ func updateConnectivityRuleModelFromSpec(model *connectivityRuleResourceModel, c
 	var diags diag.Diagnostics
 
 	model.ID = types.StringValue(connectivityRule.GetId())
+	// Reads always report a project, the account's default one included, so this is never empty.
+	model.ProjectID = types.StringValue(connectivityRule.GetProjectId())
 	model.AzurePeResourceID = types.StringNull()
 
 	if connectivityRule.Spec.GetPrivateRule() != nil {

--- a/internal/provider/connectivity_rule_resource.go
+++ b/internal/provider/connectivity_rule_resource.go
@@ -374,7 +374,6 @@ func updateConnectivityRuleModelFromSpec(model *connectivityRuleResourceModel, c
 	var diags diag.Diagnostics
 
 	model.ID = types.StringValue(connectivityRule.GetId())
-	// Reads always report a project, the account's default one included, so this is never empty.
 	model.ProjectID = types.StringValue(connectivityRule.GetProjectId())
 	model.AzurePeResourceID = types.StringNull()
 

--- a/internal/provider/connectivity_rule_resource_test.go
+++ b/internal/provider/connectivity_rule_resource_test.go
@@ -45,7 +45,17 @@ func TestAccConnectivityRuleResource_Public(t *testing.T) {
 				Config: testAccConnectivityRuleResourceConfig_Public(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("temporalcloud_connectivity_rule.test_public", "connectivity_type", "public"),
+					// Omitting project_id creates the rule in the account's default project, whose
+					// real ID is reported on read.
+					resource.TestCheckResourceAttrSet("temporalcloud_connectivity_rule.test_public", "project_id"),
 				),
+			},
+			// project_id is Optional+Computed, so omitting it must not leave a perpetual diff. This
+			// relies on UseStateForUnknown putting the project read back from the API into the plan;
+			// without it every plan would propose an update, which this resource always rejects.
+			{
+				Config:   testAccConnectivityRuleResourceConfig_Public(),
+				PlanOnly: true,
 			},
 			// Import state testing
 			{
@@ -166,6 +176,43 @@ func TestAccConnectivityRuleResource_Azure_Private(t *testing.T) {
 	})
 }
 
+func TestAccConnectivityRuleResource_Project(t *testing.T) {
+	projectName := createRandomName()
+	otherProjectName := createRandomName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create a public connectivity rule in an explicit project
+			{
+				Config: testAccConnectivityRuleResourceConfig_Project(projectName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("temporalcloud_connectivity_rule.test_project", "connectivity_type", "public"),
+					resource.TestCheckResourceAttrPair(
+						"temporalcloud_connectivity_rule.test_project", "project_id",
+						"temporalcloud_project.test", "id",
+					),
+				),
+			},
+			// Import state testing
+			{
+				ResourceName:      "temporalcloud_connectivity_rule.test_project",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// project_id is create-only, and connectivity rules have no update path at all, so
+			// pointing the rule at another project is rejected rather than moving it.
+			{
+				Config:      testAccConnectivityRuleResourceConfig_ProjectMoved(projectName, otherProjectName),
+				ExpectError: regexp.MustCompile("Connectivity rules cannot be updated"),
+			},
+		},
+	})
+}
+
 func TestAccConnectivityRuleResource_ValidationErrors(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -223,6 +270,44 @@ resource "temporalcloud_connectivity_rule" "test_public" {
   connectivity_type = "public"
 }
 `
+}
+
+func testAccConnectivityRuleResourceConfig_Project(projectName string) string {
+	return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_project" "test" {
+  display_name = "%s"
+}
+
+resource "temporalcloud_connectivity_rule" "test_project" {
+  connectivity_type = "public"
+  project_id        = temporalcloud_project.test.id
+}
+`, projectName)
+}
+
+func testAccConnectivityRuleResourceConfig_ProjectMoved(projectName string, otherProjectName string) string {
+	return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_project" "test" {
+  display_name = "%s"
+}
+
+resource "temporalcloud_project" "other" {
+  display_name = "%s"
+}
+
+resource "temporalcloud_connectivity_rule" "test_project" {
+  connectivity_type = "public"
+  project_id        = temporalcloud_project.other.id
+}
+`, projectName, otherProjectName)
 }
 
 func testAccConnectivityRuleResourceConfig_PublicStableIps() string {

--- a/internal/provider/connectivity_rule_resource_test.go
+++ b/internal/provider/connectivity_rule_resource_test.go
@@ -178,7 +178,6 @@ func TestAccConnectivityRuleResource_Azure_Private(t *testing.T) {
 
 func TestAccConnectivityRuleResource_Project(t *testing.T) {
 	projectName := createRandomName()
-	otherProjectName := createRandomName()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -204,10 +203,19 @@ func TestAccConnectivityRuleResource_Project(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			// project_id is create-only, and connectivity rules have no update path at all, so
-			// pointing the rule at another project is rejected rather than moving it.
+			// pointing the rule at another project is rejected rather than moving it. The guard runs
+			// before any API call, so the target project does not have to exist.
 			{
-				Config:      testAccConnectivityRuleResourceConfig_ProjectMoved(projectName, otherProjectName),
+				Config:      testAccConnectivityRuleResourceConfig_ProjectMoved(projectName),
 				ExpectError: regexp.MustCompile("Connectivity rules cannot be updated"),
+			},
+			// Destroy the rule in its own step, leaving only the project for the post-test destroy.
+			// DeleteProject reads the database directly and rejects a project that still holds
+			// resources, but a resource's delete operation reports fulfilled before its row is gone,
+			// so deleting both in one pass makes the project delete fail. Separating them puts a
+			// plan and an apply between the two deletes.
+			{
+				Config: testAccConnectivityRuleResourceConfig_ProjectOnly(projectName),
 			},
 		},
 	})
@@ -289,7 +297,7 @@ resource "temporalcloud_connectivity_rule" "test_project" {
 `, projectName)
 }
 
-func testAccConnectivityRuleResourceConfig_ProjectMoved(projectName string, otherProjectName string) string {
+func testAccConnectivityRuleResourceConfig_ProjectMoved(projectName string) string {
 	return fmt.Sprintf(`
 provider "temporalcloud" {
 
@@ -299,15 +307,23 @@ resource "temporalcloud_project" "test" {
   display_name = "%s"
 }
 
-resource "temporalcloud_project" "other" {
-  display_name = "%s"
-}
-
 resource "temporalcloud_connectivity_rule" "test_project" {
   connectivity_type = "public"
-  project_id        = temporalcloud_project.other.id
+  project_id        = "00000000000000000000000000000000"
 }
-`, projectName, otherProjectName)
+`, projectName)
+}
+
+func testAccConnectivityRuleResourceConfig_ProjectOnly(projectName string) string {
+	return fmt.Sprintf(`
+provider "temporalcloud" {
+
+}
+
+resource "temporalcloud_project" "test" {
+  display_name = "%s"
+}
+`, projectName)
 }
 
 func testAccConnectivityRuleResourceConfig_PublicStableIps() string {


### PR DESCRIPTION
Adds `project_id` to connectivity rules.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches networking resource creation and project scoping; mis-scoped rules could block namespace attachment, though behavior follows API defaults and is covered by new acceptance tests.
> 
> **Overview**
> Adds **`project_id`** to `temporalcloud_connectivity_rule` and the connectivity rule data source so rules can be created in a specific Temporal Cloud project instead of only the account default.
> 
> On create, an omitted `project_id` is optional+computed: the provider sends an empty value to the API for the default project and stores the resolved ID from read using `UseStateForUnknown` to avoid endless plan-only diffs. The field is documented as create-only (same as other immutable rule attributes; updates remain unsupported). Rules may only be attached to namespaces in the same project.
> 
> Docs and examples show a public rule in a dedicated project. Acceptance tests cover default-project `project_id`, plan-only stability, explicit project creation, import, and rejecting a `project_id` change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f44bce4bf1fdf665000136431a1853237cad9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->